### PR TITLE
Add support for ChatCompletion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 This package provides classes and functions for automated, AI-assisted revision of manuscript written using [Manubot](https://manubot.org/).
 Check out the [manuscript](https://github.com/greenelab/manubot-gpt-manuscript).
 
+We currently support the following OpenAI endpoints:
+* [`Completion`](https://platform.openai.com/docs/api-reference/completions)
+* [`Edits`](https://platform.openai.com/docs/api-reference/edits)
+* [`ChatCompletion`](https://platform.openai.com/docs/api-reference/chat).
+  * *Note* that the chat completion endpoint is not fully implemented yet.
+    The current implementation uses the chat completion endpoint in a similar way as the completion endpoint.
+    This is because new models such as `gpt-3.5-turbo` or `gpt-4` are only available through this endpoint. 
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Check out the [manuscript](https://github.com/greenelab/manubot-gpt-manuscript).
 We currently support the following OpenAI endpoints:
 * [`Completion`](https://platform.openai.com/docs/api-reference/completions)
 * [`Edits`](https://platform.openai.com/docs/api-reference/edits)
-* [`ChatCompletion`](https://platform.openai.com/docs/api-reference/chat).
-  * *Note* that the chat completion endpoint is not fully implemented yet.
-    The current implementation uses the chat completion endpoint in a similar way as the completion endpoint.
-    This is because new models such as `gpt-3.5-turbo` or `gpt-4` are only available through this endpoint. 
+* [`ChatCompletion`](https://platform.openai.com/docs/api-reference/chat)
+  * *Note:* this endpoint is not fully implemented yet.
+    The current implementation uses the chat completion endpoint in a similar way as we use the completion endpoint (each paragraph is revised independently in a query).
+    This is because new models such as `gpt-3.5-turbo` or `gpt-4` are only available through the chat completion endpoint. 
 
 ## Installation
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - openai=0.25.*
+  - openai>=0.27
   - pip
   - pytest=7.*
   - python=3.10.*

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "openai>=0.25",
+        "openai>=0.27",
         "pyyaml",
     ],
     classifiers=[

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -799,7 +799,7 @@ This model's maximum context length is 4097 tokens, however you requested 17570 
 -->
     """.strip()
     assert starts_with_similar(
-        paragraph_revised, error_message, 0.9 if not model.edit_endpoint else 0.30
+        paragraph_revised, error_message, 0.55 if not model.edit_endpoint else 0.30
     )
 
     # remove the multiline html comment at the top of the revised paragraph

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -605,15 +605,13 @@ Changes are presented to the user through the GitHub interface for author review
     paragraph = [sentence.strip() for sentence in paragraph]
     assert len(paragraph) == 6
 
-    model = GPT3CompletionModel(
-        title="A publishing infrastructure for AI-assisted academic authoring",
-        keywords=[
-            "manubot",
-            "artificial intelligence",
-            "scholarly publishing",
-            "software",
-        ],
-    )
+    model.title = "A publishing infrastructure for AI-assisted academic authoring"
+    model.keywords = [
+        "manubot",
+        "artificial intelligence",
+        "scholarly publishing",
+        "software",
+    ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
         paragraph, "introduction", model
@@ -947,15 +945,13 @@ This work lays the foundation for a future where academic manuscripts are constr
     paragraph = [sentence.strip() for sentence in paragraph]
     assert len(paragraph) == 4
 
-    model = GPT3CompletionModel(
-        title="A publishing infrastructure for AI-assisted academic authoring",
-        keywords=[
-            "manubot",
-            "artificial intelligence",
-            "scholarly publishing",
-            "software",
-        ],
-    )
+    model.title = "A publishing infrastructure for AI-assisted academic authoring"
+    model.keywords = [
+        "manubot",
+        "artificial intelligence",
+        "scholarly publishing",
+        "software",
+    ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
         paragraph, "conclusions", model
@@ -1182,15 +1178,13 @@ With the most complex model, `text-davinci-003`, the cost per run is under $0.50
     paragraph = [sentence.strip() for sentence in paragraph]
     assert len(paragraph) == 5
 
-    model = GPT3CompletionModel(
-        title="A publishing infrastructure for AI-assisted academic authoring",
-        keywords=[
-            "manubot",
-            "artificial intelligence",
-            "scholarly publishing",
-            "software",
-        ],
-    )
+    model.title = "A publishing infrastructure for AI-assisted academic authoring"
+    model.keywords = [
+        "manubot",
+        "artificial intelligence",
+        "scholarly publishing",
+        "software",
+    ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
         paragraph, "methods", model

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -75,7 +75,7 @@ def test_model_object_init_default_language_model():
         keywords=["test", "keywords"],
     )
 
-    assert model.model_parameters["engine"] == "text-davinci-003"
+    assert model.model_parameters["model"] == "text-davinci-003"
 
 
 @mock.patch.dict("os.environ", {env_vars.LANGUAGE_MODEL: "text-curie-001"})
@@ -85,7 +85,7 @@ def test_model_object_init_read_language_model_from_environment():
         keywords=["test", "keywords"],
     )
 
-    assert model.model_parameters["engine"] == "text-curie-001"
+    assert model.model_parameters["model"] == "text-curie-001"
 
 
 @mock.patch.dict("os.environ", {env_vars.LANGUAGE_MODEL: ""})
@@ -95,7 +95,7 @@ def test_model_object_init_read_language_model_from_environment_is_empty():
         keywords=["test", "keywords"],
     )
 
-    assert model.model_parameters["engine"] == "text-davinci-003"
+    assert model.model_parameters["model"] == "text-davinci-003"
 
 
 def test_get_prompt_for_abstract():

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -287,6 +287,7 @@ In transcriptomics, genes with correlated expression often share functions or ar
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_abstract_ccc(model):
@@ -346,6 +347,7 @@ CCC is a highly-efficient, next-generation not-only-linear correlation coefficie
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_abstract_phenoplier(model):
@@ -408,6 +410,7 @@ By incorporating groups of co-expressed genes, PhenoPLIER can contextualize gene
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_abstract_ai_revision(model):
@@ -465,6 +468,7 @@ Given the amount of time that researchers put into crafting prose, we expect thi
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_introduction_paragraph_with_single_and_multiple_citations_together(
@@ -525,6 +529,7 @@ Therefore, advanced correlation coefficients could immediately find wide applica
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_introduction_paragraph_with_citations_and_paragraph_is_the_first(model):
@@ -582,6 +587,7 @@ Integrating functional genomics data and GWAS data [@doi:10.1038/s41588-018-0081
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_introduction_paragraph_with_citations_and_paragraph_is_the_last(model):
@@ -640,6 +646,7 @@ Changes are presented to the user through the GitHub interface for author review
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_results_paragraph_with_short_inline_formulas_and_refs_to_figures_and_citations(
@@ -691,6 +698,7 @@ This kind of simulated data, recently revisited with the "Datasaurus" [@url:http
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_results_paragraph_with_lists_and_refs_to_sections_and_subfigs(model):
@@ -752,6 +760,7 @@ We performed extensive simulations for our regression model ([Supplementary Note
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_results_paragraph_is_too_long(model):
@@ -805,6 +814,7 @@ This model's maximum context length is 4097 tokens, however you requested 17570 
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_discussion_paragraph_with_markdown_formatting_and_citations(model):
@@ -858,6 +868,7 @@ Its nonlinear correlation with *AC068580.6* might unveil other important players
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_discussion_paragraph_with_minor_math_and_refs_to_sections_and_websites(
@@ -918,6 +929,7 @@ The regression model, however, is approximately well-calibrated, and we did not 
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_conclusions_paragraph_with_simple_text(model):
@@ -970,6 +982,7 @@ This work lays the foundation for a future where academic manuscripts are constr
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_methods_paragraph_with_inline_equations_and_figure_refs(model):
@@ -1025,6 +1038,7 @@ Therefore, the CCC algorithm (shown below) searches for this optimal number of c
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_methods_paragraph_with_figure_table_and_equation_refs(model):
@@ -1086,6 +1100,7 @@ The model can also detect LVs associated with relevant traits (Figure @fig:lv246
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_methods_paragraph_with_inline_math_and_equations(model):
@@ -1150,6 +1165,7 @@ Since S-PrediXcan provides tissue-specific direction of effects (for instance, w
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_methods_paragraph_without_fig_table_reference(model):
@@ -1203,6 +1219,7 @@ With the most complex model, `text-davinci-003`, the cost per run is under $0.50
     [
         GPT3CompletionModel(None, None),
         GPT3CompletionModel(None, None, edit_endpoint=True),
+        GPT3CompletionModel(None, None, model_engine="gpt-3.5-turbo"),
     ],
 )
 def test_revise_methods_paragraph_with_many_tokens(model):


### PR DESCRIPTION
This PR fixes issue #8. The work here keeps the same prompts and structure (one independent query to revise each paragraph) but allows to use the new `gpt-3.5-turbo` model based on the ChatCompletion endpoint. This also allows using all models based on this API, including the new GPT-4 that will be openly released later.