### PR TITLE
Add basic support for custom prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ shutil.rmtree(output_folder, ignore_errors=True)
 output_folder.mkdir(parents=True, exist_ok=True)
 
 # then I revise the manuscript
-me.revise_manuscript(output_folder, model, debug=True)
+me.revise_manuscript(output_folder, model)
 
 # here I move the revised manuscript back to the content folder
 # CAUTION: this will overwrite the original manuscript

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -79,8 +79,8 @@ class ManuscriptEditor:
     @staticmethod
     def revise_and_write_paragraph(
         paragraph: list[str],
-        section_name: str,
         revision_model: ManuscriptRevisionModel,
+        section_name: str = None,
         outfile=None,
     ) -> None | tuple[str, str]:
         """
@@ -334,7 +334,7 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
 
                     # revise and write paragraph to output file
                     self.revise_and_write_paragraph(
-                        paragraph, section_name, revision_model, outfile
+                        paragraph, revision_model, section_name, outfile
                     )
 
                     # clear the paragraph list
@@ -375,7 +375,7 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
             # output file
             if paragraph:
                 self.revise_and_write_paragraph(
-                    paragraph, section_name, revision_model, outfile
+                    paragraph, revision_model, section_name, outfile
                 )
 
     def revise_manuscript(

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -382,6 +382,7 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
         self,
         output_dir: Path | str,
         revision_model: ManuscriptRevisionModel,
+        debug: bool = False,
     ):
         """
         Revises all the files in the content directory of the manuscript sorted

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -382,7 +382,6 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
         self,
         output_dir: Path | str,
         revision_model: ManuscriptRevisionModel,
-        debug: bool = False,
     ):
         """
         Revises all the files in the content directory of the manuscript sorted
@@ -403,8 +402,14 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
                 filenames_to_revise = None
 
         for filename in sorted(self.content_dir.glob("*.md")):
+            # ignore front-matter file
+            if "front-matter" in filename.name:
+                continue
+
             filename_section = self.get_section_from_filename(filename.name)
-            if filename_section is None:
+
+            # we do not process the file if it has no section and there is no custom prompt
+            if filename_section is None and env_vars.CUSTOM_PROMPT not in os.environ:
                 continue
 
             if (

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -410,7 +410,10 @@ ERROR: the paragraph below could not be revised with the AI model due to the fol
             filename_section = self.get_section_from_filename(filename.name)
 
             # we do not process the file if it has no section and there is no custom prompt
-            if filename_section is None and env_vars.CUSTOM_PROMPT not in os.environ:
+            if filename_section is None and (
+                env_vars.CUSTOM_PROMPT not in os.environ
+                or os.environ[env_vars.CUSTOM_PROMPT].strip() == ""
+            ):
                 continue
 
             if (

--- a/libs/manubot_ai_editor/env_vars.py
+++ b/libs/manubot_ai_editor/env_vars.py
@@ -53,9 +53,11 @@ RETRY_COUNT = "AI_EDITOR_RETRY_COUNT"
 FILENAMES_TO_REVISE = "AI_EDITOR_FILENAMES_TO_REVISE"
 
 # It allows to specify a single, custom prompt for all sections. For example:
-# "proofread and revise the following paragraph", where the tool will automatically
-# append the characters ':\n\n' followed by the paragraph at the end of the prompt.
-# Another example is "proofread and revise the following paragraph from the section {section_name} of scientific mauscript:\n\n{paragraph_text}".
+# "proofread and revise the following paragraph"; in this case, the tool will automatically
+# append the characters ':\n\n' followed by the paragraph.
+# It is also possible to include placeholders in the prompt, which will be replaced
+# by the corresponding values. For example, "proofread and revise the following
+# paragraph from the section {section_name} of a scientific manuscript with title '{title}'".
 # The complete list of placeholders is: {paragraph_text}, {section_name},
-# {manuscript_title}, {manuscript_keywords}.
+# {title}, {keywords}.
 CUSTOM_PROMPT = "AI_EDITOR_CUSTOM_PROMPT"

--- a/libs/manubot_ai_editor/env_vars.py
+++ b/libs/manubot_ai_editor/env_vars.py
@@ -16,6 +16,8 @@ if you want to provide a custom prompt, then you need to add a line like this to
 OPENAI_API_KEY = "OPENAI_API_KEY"
 
 # Language model to use. For example, "text-davinci-003", "gpt-3.5-turbo", "gpt-3.5-turbo-0301", etc
+# The tool currently supports the "chat/completions", "completions", and "edits" endpoints, and you can check
+# compatible models here: https://platform.openai.com/docs/models/model-endpoint-compatibility
 LANGUAGE_MODEL = "AI_EDITOR_LANGUAGE_MODEL"
 
 # Model parameter: max_tokens

--- a/libs/manubot_ai_editor/env_vars.py
+++ b/libs/manubot_ai_editor/env_vars.py
@@ -1,8 +1,15 @@
 """
 This file contains environment variables names used by manubot-ai-editor
-package. Several of them allow to specify different parameters when calling the
-OpenAI model, such as LAGUANGE_MODEL or MAX_TOKENS_PER_REQUEST. For this, see
-more details in https://beta.openai.com/docs/api-reference/completions/create
+package. They allow to specify different parameters when calling the
+OpenAI model, such as the language model or the maximum tokens per request
+(see more details in https://beta.openai.com/docs/api-reference/completions/create).
+
+If you are using our GitHub Actions workflow provided by manubot/rootstock, you need
+to modify the "Revise manuscript" step in the workflow file (.github/workflows/ai-revision.yaml)
+by adding the environment variable name specificed in the _value_ of the variables. For instance,
+if you want to provide a custom prompt, then you need to add a line like this to the workflow:
+
+    AI_EDITOR_CUSTOM_PROMPT="proofread the following paragraph"
 """
 
 # OpenAI API key to use

--- a/libs/manubot_ai_editor/env_vars.py
+++ b/libs/manubot_ai_editor/env_vars.py
@@ -8,7 +8,7 @@ more details in https://beta.openai.com/docs/api-reference/completions/create
 # OpenAI API key to use
 OPENAI_API_KEY = "OPENAI_API_KEY"
 
-# Language model to use. For example, "text-davinci-003"
+# Language model to use. For example, "text-davinci-003", "gpt-3.5-turbo", "gpt-3.5-turbo-0301", etc
 LANGUAGE_MODEL = "AI_EDITOR_LANGUAGE_MODEL"
 
 # Model parameter: max_tokens

--- a/libs/manubot_ai_editor/env_vars.py
+++ b/libs/manubot_ai_editor/env_vars.py
@@ -51,3 +51,11 @@ RETRY_COUNT = "AI_EDITOR_RETRY_COUNT"
 # If specified, only these file names will be revised. Multiple files can be
 # specified, separated by commas. For example: "01.intro.md,02.review.md"
 FILENAMES_TO_REVISE = "AI_EDITOR_FILENAMES_TO_REVISE"
+
+# It allows to specify a single, custom prompt for all sections. For example:
+# "proofread and revise the following paragraph", where the tool will automatically
+# append the characters ':\n\n' followed by the paragraph at the end of the prompt.
+# Another example is "proofread and revise the following paragraph from the section {section_name} of scientific mauscript:\n\n{paragraph_text}".
+# The complete list of placeholders is: {paragraph_text}, {section_name},
+# {manuscript_title}, {manuscript_keywords}.
+CUSTOM_PROMPT = "AI_EDITOR_CUSTOM_PROMPT"

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -253,7 +253,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
         self.several_spaces_pattern = re.compile(r"\s+")
 
     def get_prompt(
-        self, paragraph_text: str, section_name: str
+        self, paragraph_text: str, section_name: str = None
     ) -> str | tuple[str, str]:
         """
         Returns the prompt to be used for the revision of a paragraph that
@@ -417,7 +417,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
             "tokens_in_completion": tokens_in_completion,
         }
 
-    def revise_paragraph(self, paragraph_text, section_name):
+    def revise_paragraph(self, paragraph_text: str, section_name: str = None):
         """
         It revises a paragraph using GPT-3 completion model.
 

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -270,7 +270,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
              2) the paragraph to revise.
         """
 
-        if env_vars.CUSTOM_PROMPT in os.environ:
+        if env_vars.CUSTOM_PROMPT in os.environ and os.environ[env_vars.CUSTOM_PROMPT].strip() != "":
             prompt = os.environ[env_vars.CUSTOM_PROMPT]
             print(
                 f"Using custom prompt from environment variable '{env_vars.CUSTOM_PROMPT}'"
@@ -283,12 +283,10 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
                 "keywords": ", ".join(self.keywords),
             }
 
-            if "{paragraph_text}" not in prompt:
-                prompt += ":\n\n{paragraph_text}"
-
-            return prompt.format(**placeholders)
-
-        if section_name in ("abstract",):
+            # FIXME: if {paragraph_text} is in the prompt, this won't work for the edits endpoint
+            #  a simple workaround is to remove {paragraph_text} from the prompt
+            prompt = prompt.format(**placeholders)
+        elif section_name in ("abstract",):
             prompt = f"""
                 Revise the following paragraph from the {section_name} of an academic paper (with the title '{self.title}' and keywords '{", ".join(self.keywords)}')
                 so the research problem/question is clear,

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -280,7 +280,18 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
             print(
                 f"Using custom prompt from environment variable '{env_vars.CUSTOM_PROMPT}'"
             )
-            return f"{prompt}:\n\n{paragraph_text}"
+
+            placeholders = {
+                "paragraph_text": paragraph_text,
+                "section_name": section_name,
+                "title": self.title,
+                "keywords": ", ".join(self.keywords),
+            }
+
+            if "{paragraph_text}" not in prompt:
+                prompt += ":\n\n{paragraph_text}"
+
+            return prompt.format(**placeholders)
 
         if section_name in ("abstract",):
             prompt = f"""

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -341,12 +341,17 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
                    and the text has a clear sentence structure
             """.strip()
         else:
-            prompt = f"""
-                Revise the following paragraph from the {section_name.capitalize()} section of an academic paper (with the title '{self.title}' and keywords '{", ".join(self.keywords)}')
+            prompt = "Revise the following paragraph"
+
+            if section_name is not None and section_name != "":
+                prompt += f" from the {section_name.capitalize()} section"
+
+            prompt += f" of an academic paper (with title '{self.title}' and keywords '{', '.join(self.keywords)}')"
+            prompt += """
                 so
-                   the text minimizes the use of jargon,
-                   the text grammar is correct, spelling errors are fixed,
-                   and the text has a clear sentence structure
+                    the text minimizes the use of jargon,
+                    the text grammar is correct, spelling errors are fixed,
+                    and the text has a clear sentence structure
             """
 
         prompt = self.several_spaces_pattern.sub(" ", prompt).strip()

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -274,6 +274,14 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
              1) the instructions to be used by the model for the revision of the paragraph,
              2) the paragraph to revise.
         """
+
+        if env_vars.CUSTOM_PROMPT in os.environ:
+            prompt = os.environ[env_vars.CUSTOM_PROMPT]
+            print(
+                f"Using custom prompt from environment variable '{env_vars.CUSTOM_PROMPT}'"
+            )
+            return f"{prompt}:\n\n{paragraph_text}"
+
         if section_name in ("abstract",):
             prompt = f"""
                 Revise the following paragraph from the {section_name} of an academic paper (with the title '{self.title}' and keywords '{", ".join(self.keywords)}')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.4.2",
+    version="0.4.3",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.4.3",
+    version="0.4.4",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.4.1",
+    version="0.4.2",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.4.5",
+    version="0.4.6",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.4.4",
+    version="0.4.5",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",

--- a/tests/manuscripts/ccc_non_standard_filenames/00.front-matter.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/00.front-matter.md
@@ -1,0 +1,49 @@
+{##
+  This file contains a Jinja2 front-matter template that adds version and authorship information.
+  Changing the Jinja2 templates in this file may cause incompatibility with Manubot updates.
+  Pandoc automatically inserts title from metadata.yaml, so it is not included in this template.
+##}
+
+_A DOI-citable version of this manuscript is available at <https://doi.org/10.1101/2022.06.15.496326>_.
+
+<!-- {## Template to insert build date and source ##}
+<small><em>
+This manuscript
+{% if manubot.ci_source is defined and manubot.ci_source.provider == "appveyor" -%}
+([permalink]({{manubot.ci_source.artifact_url}}))
+{% elif manubot.html_url_versioned is defined -%}
+([permalink]({{manubot.html_url_versioned}}))
+{% endif -%}
+was automatically generated
+{% if manubot.ci_source is defined -%}
+from [{{manubot.ci_source.repo_slug}}@{{manubot.ci_source.commit | truncate(length=7, end='', leeway=0)}}](https://github.com/{{manubot.ci_source.repo_slug}}/tree/{{manubot.ci_source.commit}})
+{% endif -%}
+on {{manubot.date}}.
+</em></small> -->
+
+## Authors
+
+{## Template for listing authors ##}
+{% for author in manubot.authors %}
++ **{{author.name}}**<br>
+  {%- if author.orcid is defined and author.orcid is not none %}
+    ![ORCID icon](images/orcid.svg){.inline_icon width=16 height=16}
+    [{{author.orcid}}](https://orcid.org/{{author.orcid}})
+  {%- endif %}
+  {%- if author.github is defined and author.github is not none %}
+    · ![GitHub icon](images/github.svg){.inline_icon width=16 height=16}
+    [{{author.github}}](https://github.com/{{author.github}})
+  {%- endif %}
+  {%- if author.twitter is defined and author.twitter is not none %}
+    · ![Twitter icon](images/twitter.svg){.inline_icon width=16 height=16}
+    [{{author.twitter}}](https://twitter.com/{{author.twitter}})
+  {%- endif %}<br>
+  <small>
+  {%- if author.affiliations is defined and author.affiliations|length %}
+     {{author.affiliations | join('; ')}}
+  {%- endif %}
+  {%- if author.funders is defined and author.funders|length %}
+     · Funded by {{author.funders | join('; ')}}
+  {%- endif %}
+  </small>
+{% endfor %}

--- a/tests/manuscripts/ccc_non_standard_filenames/01.ab.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/01.ab.md
@@ -1,0 +1,10 @@
+## Abstract {.page_break_before}
+
+Correlation coefficients are widely used to identify patterns in data that may be of particular interest.
+In transcriptomics, genes with correlated expression often share functions or are part of disease-relevant biological processes.
+Here we introduce the Clustermatch Correlation Coefficient (CCC), an efficient, easy-to-use and not-only-linear coefficient based on machine learning models.
+CCC reveals biologically meaningful linear and nonlinear patterns missed by standard, linear-only correlation coefficients.
+CCC captures general patterns in data by comparing clustering solutions while being much faster than state-of-the-art coefficients such as the Maximal Information Coefficient.
+When applied to human gene expression data, CCC identifies robust linear relationships while detecting nonlinear patterns associated, for example, with sex differences that are not captured by linear-only coefficients.
+Gene pairs highly ranked by CCC were enriched for interactions in integrated networks built from protein-protein interaction, transcription factor regulation, and chemical and genetic perturbations, suggesting that CCC could detect functional relationships that linear-only methods missed.
+CCC is a highly-efficient, next-generation not-only-linear correlation coefficient that can readily be applied to genome-scale data and other domains across different data types.

--- a/tests/manuscripts/ccc_non_standard_filenames/02.beginning.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/02.beginning.md
@@ -1,0 +1,37 @@
+## Introduction
+
+New technologies have vastly improved data collection, generating a deluge of information across different disciplines.
+This large amount of data provides new opportunities to address unanswered scientific questions, provided we have efficient tools capable of identifying multiple types of underlying patterns.
+Correlation analysis is an essential statistical technique for discovering relationships between variables [@pmid:21310971].
+Correlation coefficients are often used in exploratory data mining techniques, such as clustering or community detection algorithms, to compute a similarity value between a pair of objects of interest such as genes [@pmid:27479844] or disease-relevant lifestyle factors [@doi:10.1073/pnas.1217269109].
+Correlation methods are also used in supervised tasks, for example, for feature selection to improve prediction accuracy [@pmid:27006077; @pmid:33729976].
+The Pearson correlation coefficient is ubiquitously deployed across application domains and diverse scientific areas.
+Thus, even minor and significant improvements in these techniques could have enormous consequences in industry and research.
+
+
+In transcriptomics, many analyses start with estimating the correlation between genes.
+More sophisticated approaches built on correlation analysis can suggest gene function [@pmid:21241896], aid in discovering common and cell lineage-specific regulatory networks [@pmid:25915600], and capture important interactions in a living organism that can uncover molecular mechanisms in other species [@pmid:21606319; @pmid:16968540].
+The analysis of large RNA-seq datasets [@pmid:32913098; @pmid:34844637] can also reveal complex transcriptional mechanisms underlying human diseases [@pmid:27479844; @pmid:31121115; @pmid:30668570; @pmid:32424349; @pmid:34475573].
+Since the introduction of the omnigenic model of complex traits [@pmid:28622505; @pmid:31051098], gene-gene relationships are playing an increasingly important role in genetic studies of human diseases [@pmid:34845454; @doi:10.1101/2021.07.05.450786; @doi:10.1101/2021.10.21.21265342; @doi:10.1038/s41588-021-00913-z], even in specific fields such as polygenic risk scores [@doi:10.1016/j.ajhg.2021.07.003].
+In this context, recent approaches combine disease-associated genes from genome-wide association studies (GWAS) with gene co-expression networks to prioritize "core" genes directly affecting diseases [@doi:10.1186/s13040-020-00216-9; @doi:10.1101/2021.07.05.450786; @doi:10.1101/2021.10.21.21265342].
+These core genes are not captured by standard statistical methods but are believed to be part of highly-interconnected, disease-relevant regulatory networks.
+Therefore, advanced correlation coefficients could immediately find wide applications across many areas of biology, including the prioritization of candidate drug targets in the precision medicine field.
+
+
+The Pearson and Spearman correlation coefficients are widely used because they reveal intuitive relationships and can be computed quickly.
+However, they are designed to capture linear or monotonic patterns (referred to as linear-only) and may miss complex yet critical relationships.
+Novel coefficients have been proposed as metrics that capture nonlinear patterns such as the Maximal Information Coefficient (MIC) [@pmid:22174245] and the Distance Correlation (DC) [@doi:10.1214/009053607000000505].
+MIC, in particular, is one of the most commonly used statistics to capture more complex relationships, with successful applications across several domains [@pmid:33972855; @pmid:33001806; @pmid:27006077].
+However, the computational complexity makes them impractical for even moderately sized datasets [@pmid:33972855; @pmid:27333001].
+Recent implementations of MIC, for example, take several seconds to compute on a single variable pair across a few thousand objects or conditions [@pmid:33972855].
+We previously developed a clustering method for highly diverse datasets that significantly outperformed approaches based on Pearson, Spearman, DC and MIC in detecting clusters of simulated linear and nonlinear relationships with varying noise levels [@doi:10.1093/bioinformatics/bty899].
+Here we introduce the Clustermatch Correlation Coefficient (CCC), an efficient not-only-linear coefficient that works across quantitative and qualitative variables.
+CCC has a single parameter that limits the maximum complexity of relationships found (from linear to more general patterns) and computation time.
+CCC provides a high level of flexibility to detect specific types of patterns that are more important for the user, while providing safe defaults to capture general relationships.
+We also provide an efficient CCC implementation that is highly parallelizable, allowing to speed up computation across variable pairs with millions of objects or conditions.
+To assess its performance, we applied our method to gene expression data from the Genotype-Tissue Expression v8 (GTEx) project across different tissues [@doi:10.1126/science.aaz1776].
+CCC captured both strong linear relationships and novel nonlinear patterns, which were entirely missed by standard coefficients.
+For example, some of these nonlinear patterns were associated with sex differences in gene expression, suggesting that CCC can capture strong relationships present only in a subset of samples.
+We also found that the CCC behaves similarly to MIC in several cases, although it is much faster to compute.
+Gene pairs detected in expression data by CCC had higher interaction probabilities in tissue-specific gene networks from the Genome-wide Analysis of gene Networks in Tissues (GIANT) [@doi:10.1038/ng.3259].
+Furthermore, its ability to efficiently handle diverse data types (including numerical and categorical features) reduces preprocessing steps and makes it appealing to analyze large and heterogeneous repositories.

--- a/tests/manuscripts/ccc_non_standard_filenames/04.05.res.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/04.05.res.md
@@ -1,0 +1,44 @@
+### A robust and efficient not-only-linear dependence coefficient
+
+![
+**Different types of relationships in data.**
+Each panel contains a set of simulated data points described by two generic variables: $x$ and $y$.
+The first row shows Anscombe's quartet with four different datasets (from Anscombe I to IV) and 11 data points each.
+The second row contains a set of general patterns with 100 data points each.
+Each panel shows the correlation value using Pearson ($p$), Spearman ($s$) and CCC ($c$).
+Vertical and horizontal red lines show how CCC clustered data points using $x$ and $y$.
+](images/intro/relationships.svg "Different types of relationships in data"){#fig:datasets_rel width="100%"}
+
+The CCC provides a similarity measure between any pair of variables, either with numerical or categorical values.
+The method assumes that if there is a relationship between two variables/features describing $n$ data points/objects, then the **cluster**ings of those objects using each variable should **match**.
+In the case of numerical values, CCC uses quantiles to efficiently separate data points into different clusters (e.g., the median separates numerical data into two clusters).
+Once all clusterings are generated according to each variable, we define the CCC as the maximum adjusted Rand index (ARI) [@doi:10.1007/BF01908075] between them, ranging between 0 and 1.
+Details of the CCC algorithm can be found in [Methods](#sec:ccc_algo).
+
+
+We examined how the Pearson ($p$), Spearman ($s$) and CCC ($c$) correlation coefficients behaved on different simulated data patterns.
+In the first row of Figure @fig:datasets_rel, we examine the classic Anscombe's quartet [@doi:10.1080/00031305.1973.10478966], which comprises four synthetic datasets with different patterns but the same data statistics (mean, standard deviation and Pearson's correlation).
+This kind of simulated data, recently revisited with the "Datasaurus" [@url:http://www.thefunctionalart.com/2016/08/download-datasaurus-never-trust-summary.html; @doi:10.1145/3025453.3025912; @doi:10.1111/dsji.12233], is used as a reminder of the importance of going beyond simple statistics, where either undesirable patterns (such as outliers) or desirable ones (such as biologically meaningful nonlinear relationships) can be masked by summary statistics alone.
+
+
+Anscombe I contains a noisy but clear linear pattern, similar to Anscombe III where the linearity is perfect besides one outlier.
+In these two examples, CCC separates data points using two clusters (one red line for each variable $x$ and $y$), yielding 1.0 and thus indicating a strong relationship.
+Anscombe II seems to follow a partially quadratic relationship interpreted as linear by Pearson and Spearman.
+In contrast, for this potentially undersampled quadratic pattern, CCC yields a lower yet non-zero value of 0.34, reflecting a more complex relationship than a linear pattern.
+Anscombe IV shows a vertical line of data points where $x$ values are almost constant except for one outlier.
+This outlier does not influence CCC as it does for Pearson or Spearman.
+Thus $c=0.00$ (the minimum value) correctly indicates no association for this variable pair because, besides the outlier, for a single value of $x$ there are ten different values for $y$.
+This pair of variables does not fit the CCC assumption: the two clusters formed with $x$ (approximately separated by $x=13$) do not match the three clusters formed with $y$.
+The Pearson's correlation coefficient is the same across all these Anscombe's examples ($p=0.82$), whereas Spearman is 0.50 or greater.
+These simulated datasets show that both Pearson and Spearman are powerful in detecting linear patterns.
+However, any deviation in this assumption (like nonlinear relationships or outliers) affects their robustness.
+
+
+We simulated additional types of relationships (Figure @fig:datasets_rel, second row), including some previously described from gene expression data [@doi:10.1126/science.1205438; @doi:10.3389/fgene.2019.01410; @doi:10.1091/mbc.9.12.3273].
+For the random/independent pair of variables, all coefficients correctly agree with a value close to zero.
+The non-coexistence pattern, captured by all coefficients, represents a case where one gene ($x$) might be expressed while the other one ($y$) is inhibited, highlighting a potentially strong biological relationship (such as a microRNA negatively regulating another gene).
+For the other two examples (quadratic and two-lines), Pearson and Spearman do not capture the nonlinear pattern between variables $x$ and $y$.
+These patterns also show how CCC uses different degrees of complexity to capture the relationships.
+For the quadratic pattern, for example, CCC separates $x$ into more clusters (four in this case) to reach the maximum ARI.
+The two-lines example shows two embedded linear relationships with different slopes, which neither Pearson nor Spearman detect ($p=-0.12$ and $s=0.05$, respectively).
+Here, CCC increases the complexity of the model by using eight clusters for $x$ and six for $y$, resulting in $c=0.31$.

--- a/tests/manuscripts/ccc_non_standard_filenames/06.dis.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/06.dis.md
@@ -1,0 +1,57 @@
+## Discussion
+
+We introduce the Clustermatch Correlation Coefficient (CCC), an efficient not-only-linear machine learning-based statistic.
+Applying CCC to GTEx v8 revealed that it was robust to outliers and detected linear relationships as well as complex and biologically meaningful patterns that standard coefficients missed.
+In particular, CCC alone detected gene pairs with complex nonlinear patterns from the sex chromosomes, highlighting the way that not-only-linear coefficients can play in capturing sex-specific differences.
+The ability to capture these nonlinear patterns, however, extends beyond sex differences: it provides a powerful approach to detect complex relationships where a subset of samples or conditions are explained by other factors (such as differences between health and disease).
+We found that top CCC-ranked gene pairs in whole blood from GTEx were replicated in independent tissue-specific networks trained from multiple data types and attributed to cell lineages from blood, even though CCC did not have access to any cell lineage-specific information.
+This suggests that CCC can disentangle intricate cell lineage-specific transcriptional patterns missed by linear-only coefficients.
+In addition to capturing nonlinear patterns, the CCC was more similar to Spearman than Pearson, highlighting their shared robustness to outliers.
+The CCC results were concordant with MIC, but much faster to compute and thus practical for large datasets.
+Another advantage over MIC is that CCC can also process categorical variables together with numerical values.
+CCC is conceptually easy to interpret and has a single parameter that controls the maximum complexity of the detected relationships while also balancing compute time.
+
+
+Datasets such as Anscombe or "Datasaurus" highlight the value of visualization instead of relying on simple data summaries.
+While visual analysis is helpful, for many datasets examining each possible relationship is infeasible, and this is where more sophisticated and robust correlation coefficients are necessary.
+Advanced yet interpretable coefficients like CCC can focus human interpretation on patterns that are more likely to reflect real biology.
+The complexity of these patterns might reflect heterogeneity in samples that mask clear relationships between variables.
+For example, genes *UTY* - *KDM6A* (from sex chromosomes), detected by CCC, have a strong linear relationship but only in a subset of samples (males), which was not captured by linear-only coefficients.
+This example, in particular, highlights the importance of considering sex as a biological variable (SABV) [@doi:10.1038/509282a] to avoid overlooking important differences between men and women, for instance, in disease manifestations [@doi:10.1210/endrev/bnaa034; @doi:10.1038/s41593-021-00806-8].
+More generally, a not-only-linear correlation coefficient like CCC could identify significant differences between variables (such as genes) that are explained by a third factor (beyond sex differences), that would be entirely missed by linear-only coefficients.
+
+
+It is well-known that biomedical research is biased towards a small fraction of human genes [@pmid:17620606; @pmid:17472739].
+Some genes highlighted in CCC-ranked pairs (Figure @fig:upsetplot_coefs b), such as *SDS* (12q24) and *ZDHHC12* (9q34), were previously found to be the focus of fewer than expected publications [@pmid:30226837].
+It is possible that the widespread use of linear coefficients may bias researchers away from genes with complex coexpression patterns.
+A beyond-linear gene co-expression analysis on large compendia might shed light on the function of understudied genes.
+For example, gene *KLHL21* (1p36) and *AC068580.6* (*ENSG00000235027*, in 11p15) have a high CCC value and are missed by the other coefficients.
+*KLHL21* was suggested as a potential therapeutic target for hepatocellular carcinoma [@pmid:27769251] and other cancers [@pmid:29574153; @pmid:35084622].
+Its nonlinear correlation with *AC068580.6* might unveil other important players in cancer initiation or progression, potentially in subsets of samples with specific characteristics (as suggested in Figure @fig:upsetplot_coefs b).
+
+
+Not-only-linear correlation coefficients might also be helpful in the field of genetic studies.
+In this context, genome-wide association studies (GWAS) have been successful in understanding the molecular basis of common diseases by estimating the association between genotype and phenotype [@doi:10.1016/j.ajhg.2017.06.005].
+However, the estimated effect sizes of genes identified with GWAS are generally modest, and they explain only a fraction of the phenotype variance, hampering the clinical translation of these findings [@doi:10.1038/s41576-019-0127-1].
+Recent theories, like the omnigenic model for complex traits [@pmid:28622505; @pmid:31051098], argue that these observations are explained by highly-interconnected gene regulatory networks, with some core genes having a more direct effect on the phenotype than others.
+Using this omnigenic perspective, we and others [@doi:10.1101/2021.07.05.450786; @doi:10.1186/s13040-020-00216-9; @doi:10.1101/2021.10.21.21265342] have shown that integrating gene co-expression networks in genetic studies could potentially identify core genes that are missed by linear-only models alone like GWAS.
+Our results suggest that building these networks with more advanced and efficient correlation coefficients could better estimate gene co-expression profiles and thus more accurately identify these core genes.
+Approaches like CCC could play a significant role in the precision medicine field by providing the computational tools to focus on more promising genes representing potentially better candidate drug targets.
+
+
+Our analyses have some limitations.
+We worked on a sample with the top variable genes to keep computation time feasible.
+Although CCC is much faster than MIC, Pearson and Spearman are still the most computationally efficient since they only rely on simple data statistics.
+Our results, however, reveal the advantages of using more advanced coefficients like CCC for detecting and studying more intricate molecular mechanisms that replicated in independent datasets.
+The application of CCC on larger compendia, such as recount3 [@pmid:34844637] with thousands of heterogeneous samples across different conditions, can reveal other potentially meaningful gene interactions.
+The single parameter of CCC, $k_{\mathrm{max}}$, controls the maximum complexity of patterns found and also impacts the compute time.
+Our analysis suggested that $k_{\mathrm{max}}=10$ was sufficient to identify both linear and more complex patterns in gene expression.
+A more comprehensive analysis of optimal values for this parameter could provide insights to adjust it for different applications or data types.
+
+
+While linear and rank-based correlation coefficients are exceptionally fast to calculate, not all relevant patterns in biological datasets are linear.
+For example, patterns associated with sex as a biological variable are not apparent to the linear-only coefficients that we evaluated but are revealed by not-only-linear methods.
+Beyond sex differences, being able to use a method that inherently identifies patterns driven by other factors is likely to be desirable.
+Not-only-linear coefficients can also disentangle intricate yet relevant patterns from expression data alone that were replicated in models integrating different data modalities.
+CCC, in particular, is highly parallelizable, and we anticipate efficient GPU-based implementations that could make it even faster.
+The CCC is an efficient, next-generation correlation coefficient that is highly effective in transcriptome analyses and potentially useful in a broad range of other domains.

--- a/tests/manuscripts/ccc_non_standard_filenames/08.01.meths.md
+++ b/tests/manuscripts/ccc_non_standard_filenames/08.01.meths.md
@@ -1,0 +1,48 @@
+## Methods
+
+The code needed to reproduce all of our analyses and generate the figures is available in [https://github.com/greenelab/ccc](https://github.com/greenelab/ccc).
+We provide scripts to download the required data and run all the steps.
+A Docker image is provided to use the same runtime environment.
+
+
+### The CCC algorithm {#sec:ccc_algo .page_break_before}
+
+The Clustermatch Correlation Coefficient (CCC) computes a similarity value $c \in \left[0,1\right]$ between any pair of numerical or categorical features/variables $\mathbf{x}$ and $\mathbf{y}$ measured on $n$ objects.
+CCC assumes that if two features $\mathbf{x}$ and $\mathbf{y}$ are similar, then the partitioning by clustering of the $n$ objects using each feature separately should match.
+For example, given $\mathbf{x}=(11, 27, 32, 40)$ and $\mathbf{y}=10x=(110, 270, 320, 400)$, where $n=4$, partitioning each variable into two clusters ($k=2$) using their medians (29.5 for $\mathbf{x}$ and 295 for $\mathbf{y}$) would result in partition $\Omega^{\mathbf{x}}_{k=2}=(1, 1, 2, 2)$ for $\mathbf{x}$, and partition $\Omega^{\mathbf{y}}_{k=2}=(1, 1, 2, 2)$ for $\mathbf{y}$.
+Then, the agreement between $\Omega^{\mathbf{x}}_{k=2}$ and $\Omega^{\mathbf{y}}_{k=2}$ can be computed using any measure of similarity between partitions, like the adjusted Rand index (ARI) [@doi:10.1007/BF01908075].
+In that case, it will return the maximum value (1.0 in the case of ARI).
+Note that the same value of $k$ might not be the right one to find a relationship between any two features.
+For instance, in the quadratic example in Figure @fig:datasets_rel, CCC returns a value of 0.36 (grouping objects in four clusters using one feature and two using the other).
+If we used only two clusters instead, CCC would return a similarity value of 0.02.
+Therefore, the CCC algorithm (shown below) searches for this optimal number of clusters given a maximum $k$, which is its single parameter $k_{\mathrm{max}}$.
+
+![
+](images/intro/ccc_algorithm/ccc_algorithm.svg "CCC algorithm"){width="75%"}
+
+The main function of the algorithm, `ccc`, generates a list of partitionings $\Omega^{\mathbf{x}}$ and $\Omega^{\mathbf{y}}$ (lines 14 and 15), for each feature $\mathbf{x}$ and $\mathbf{y}$.
+Then, it computes the ARI between each partition in $\Omega^{\mathbf{x}}$ and $\Omega^{\mathbf{y}}$ (line 16), and then it keeps the pair that generates the maximum ARI.
+Finally, since ARI does not have a lower bound (it could return negative values, which in our case are not meaningful), CCC returns only values between 0 and 1 (line 17).
+
+
+Interestingly, since CCC only needs a pair of partitions to compute a similarity value, any type of feature that can be used to perform clustering/grouping is supported.
+If the feature is numerical (lines 2 to 5 in the `get_partitions` function), then quantiles are used for clustering (for example, the median generates $k=2$ clusters of objects), from $k=2$ to $k=k_{\mathrm{max}}$.
+If the feature is categorical (lines 7 to 9), the categories are used to group objects together.
+Consequently, since features are internally categorized into clusters, numerical and categorical variables can be naturally integrated since clusters do not need an order.
+
+
+For all our analyses we used $k_{\mathrm{max}}=10$.
+This means that for each gene pair, 18 partitions are generated (9 for each gene, from $k=2$ to $k=10$), and 81 ARI comparisons are performed.
+Smaller values of $k_{\mathrm{max}}$ can reduce computation time, although at the expense of missing more complex/general relationships.
+Our examples in Figure @fig:datasets_rel suggest that using $k_{\mathrm{max}}=2$ would force CCC to find linear-only patterns, which could be a valid use case scenario where only this kind of relationships are desired.
+In addition, $k_{\mathrm{max}}=2$ implies that only two partitions are generated, and only one ARI comparison is performed.
+In this regard, our Python implementation of CCC provides flexibility in specifying $k_{\mathrm{max}}$.
+For instance, instead of the maximum $k$ (an integer), the parameter could be a custom list of integers: for example, `[2, 5, 10]` will partition the data into two, five and ten clusters.
+
+
+For a single pair of features (genes in our study), generating partitions or computing their similarity can be parallelized.
+We used three CPU cores in our analyses to speed up the computation of CCC.
+A future improved implementation of CCC could potentially use graphical processing units (GPU) to parallelize its computation further.
+
+
+A Python implementation of CCC (optimized with `numba` [@doi:10.1145/2833157.2833162]) can be found in our Github repository [@url:https://github.com/greenelab/clustermatch-gene-expr], as well as a package published in the Python Package Index (PyPI) that can be easily installed.

--- a/tests/manuscripts/ccc_non_standard_filenames/metadata.yaml
+++ b/tests/manuscripts/ccc_non_standard_filenames/metadata.yaml
@@ -1,0 +1,50 @@
+---
+title: "An efficient not-only-linear correlation coefficient based on machine learning"
+keywords:
+  - correlation coefficient
+  - nonlinear relationships
+  - gene expression
+lang: en-US
+authors:
+  - name: Milton Pividori
+    github: miltondp
+    initials: MP
+    orcid: 0000-0002-3035-4403
+    twitter: miltondp
+    email: miltondp@gmail.com
+    affiliations:
+      - Department of Genetics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA 19104, USA
+    funders:
+      - The Gordon and Betty Moore Foundation GBMF 4552
+      - The National Human Genome Research Institute (R01 HG010067)
+  
+  - name: Marylyn D. Ritchie
+    initials: MDR
+    orcid: 0000-0002-1208-1720
+    twitter: MarylynRitchie
+    email: marylyn@pennmedicine.upenn.edu
+    affiliations:
+      - Department of Genetics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA 19104, USA
+
+  - name: Diego H. Milone
+    github: dmilone
+    initials: DHM
+    orcid: 0000-0003-2182-4351
+    twitter: d1001
+    email: dmilone@sinc.unl.edu.ar 
+    affiliations:
+      - Research Institute for Signals, Systems and Computational Intelligence (sinc(i)), Universidad Nacional del Litoral, Consejo Nacional de Investigaciones Científicas y Técnicas (CONICET), Santa Fe CP3000, Argentina
+
+  - name: Casey S. Greene
+    github: cgreene
+    initials: CSG
+    orcid: 0000-0001-8713-9213
+    twitter: GreeneScientist
+    email: casey.s.greene@cuanschutz.edu
+    affiliations:
+      - Center for Health AI, University of Colorado School of Medicine, Aurora, CO 80045, USA
+      - Department of Biochemistry and Molecular Genetics, University of Colorado School of Medicine, Aurora, CO 80045, USA
+    funders:
+      - The Gordon and Betty Moore Foundation (GBMF 4552)
+      - The National Human Genome Research Institute (R01 HG010067)
+      - The National Cancer Institute (R01 CA237170)

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -27,47 +27,6 @@ def test_model_object_init_without_openai_api_key():
         os.environ = _environ
 
 
-def test_get_prompt_no_custom_prompt():
-    model = GPT3CompletionModel(
-        title="Test title",
-        keywords=["test", "keywords"],
-    )
-
-    paragraph_text = """
-This is the first sentence.
-And this is the second sentence.
-Finally, the third sentence.
-    """.strip()
-
-    prompt = model.get_prompt(paragraph_text, "introduction")
-    assert prompt.startswith("Revise the following paragraph from the ")
-    assert prompt.endswith(paragraph_text[-20:])
-
-
-@mock.patch.dict(
-    "os.environ",
-    {env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph"},
-)
-def test_get_prompt_custom_prompt_no_placeholders():
-    model = GPT3CompletionModel(
-        title="Test title",
-        keywords=["test", "keywords"],
-    )
-
-    paragraph_text = """
-This is the first sentence.
-And this is the second sentence.
-Finally, the third sentence.
-    """.strip()
-
-    prompt = model.get_prompt(paragraph_text, "introduction")
-    assert (
-        prompt == f"proofread and revise the following paragraph:\n\n{paragraph_text}"
-    )
-
-    # TODO: add other sections, should return same output
-
-
 @mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
 def test_model_object_init_with_openai_api_key_as_environment_variable():
     GPT3CompletionModel(

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -358,7 +358,7 @@ CCC is a highly-efficient, next-generation not-only-linear correlation coefficie
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "abstract", model
+        paragraph, model, "abstract"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -421,7 +421,7 @@ By incorporating groups of co-expressed genes, PhenoPLIER can contextualize gene
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "abstract", model
+        paragraph, model, "abstract"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -479,7 +479,7 @@ Given the amount of time that researchers put into crafting prose, we expect thi
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "abstract", model
+        paragraph, model, "abstract"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -540,7 +540,7 @@ Therefore, advanced correlation coefficients could immediately find wide applica
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "introduction", model
+        paragraph, model, "introduction"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -598,7 +598,7 @@ Integrating functional genomics data and GWAS data [@doi:10.1038/s41588-018-0081
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "introduction", model
+        paragraph, model, "introduction"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -655,7 +655,7 @@ Changes are presented to the user through the GitHub interface for author review
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "introduction", model
+        paragraph, model, "introduction"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -712,7 +712,7 @@ This kind of simulated data, recently revisited with the "Datasaurus" [@url:http
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "results", model
+        paragraph, model, "results"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -767,7 +767,7 @@ We performed extensive simulations for our regression model ([Supplementary Note
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "results", model
+        paragraph, model, "results"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -824,7 +824,7 @@ We sought to systematically analyze discrepant scores to assess whether associat
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "results", model
+        paragraph, model, "results"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -882,7 +882,7 @@ Its nonlinear correlation with *AC068580.6* might unveil other important players
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "discussion", model
+        paragraph, model, "discussion"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -939,7 +939,7 @@ The regression model, however, is approximately well-calibrated, and we did not 
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "discussion", model
+        paragraph, model, "discussion"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -995,7 +995,7 @@ This work lays the foundation for a future where academic manuscripts are constr
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "conclusions", model
+        paragraph, model, "conclusions"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1050,7 +1050,7 @@ Therefore, the CCC algorithm (shown below) searches for this optimal number of c
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1105,7 +1105,7 @@ The model can also detect LVs associated with relevant traits (Figure @fig:lv246
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1178,7 +1178,7 @@ Since S-PrediXcan provides tissue-specific direction of effects (for instance, w
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1228,7 +1228,7 @@ With the most complex model, `text-davinci-003`, the cost per run is under $0.50
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1331,7 +1331,7 @@ $$ {#eq:reg:var_gene}
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1362,7 +1362,7 @@ Since the gold standard of drug-disease medical indications is described with Di
     model = RandomManuscriptRevisionModel()
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert isinstance(paragraph_text, str)
@@ -1389,7 +1389,7 @@ We adjusted the $p$-values using the Benjamini-Hochberg procedure.
     model = RandomManuscriptRevisionModel()
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods"
     )
     assert paragraph_text is not None
     assert isinstance(paragraph_text, str)

--- a/tests/test_completion_model.py
+++ b/tests/test_completion_model.py
@@ -27,6 +27,47 @@ def test_model_object_init_without_openai_api_key():
         os.environ = _environ
 
 
+def test_get_prompt_no_custom_prompt():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert prompt.startswith("Revise the following paragraph from the ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+@mock.patch.dict(
+    "os.environ",
+    {env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph"},
+)
+def test_get_prompt_custom_prompt_no_placeholders():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt == f"proofread and revise the following paragraph:\n\n{paragraph_text}"
+    )
+
+    # TODO: add other sections, should return same output
+
+
 @mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
 def test_model_object_init_with_openai_api_key_as_environment_variable():
     GPT3CompletionModel(

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -887,7 +887,7 @@ And finally, a third sentence so we have more than 2.
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, "methods", model
+        paragraph, model, "methods",
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -990,3 +990,71 @@ def test_revise_entire_manuscript_list_of_selected_files_is_empty(tmp_path, mode
 
     output_md_files = list(output_folder.glob("*.md"))
     assert len(output_md_files) == 12
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.FILENAMES_TO_REVISE: "",
+    },
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        RandomManuscriptRevisionModel(),
+        # GPT3CompletionModel(None, None),
+    ],
+)
+def test_revise_entire_manuscript_non_standard_filenames_without_custom_prompt(tmp_path, model):
+    # in this case, the list of selected files is empty and files have non standard names,
+    # so none of them are revised
+    print(f"\n{str(tmp_path)}\n")
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc_non_standard_filenames",
+    )
+
+    model.title = me.title
+    model.keywords = me.keywords
+
+    output_folder = tmp_path
+    assert output_folder.exists()
+
+    me.revise_manuscript(output_folder, model)
+
+    output_md_files = list(output_folder.glob("*.md"))
+    assert len(output_md_files) == 0
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.FILENAMES_TO_REVISE: "",
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph with manuscript title '{title}': {paragraph_text}"
+    },
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        RandomManuscriptRevisionModel(),
+        # GPT3CompletionModel(None, None),
+    ],
+)
+def test_revise_entire_manuscript_non_standard_filenames_with_custom_prompt(tmp_path, model):
+    # in this case, the list of selected files is empty but there is a custom prompt, so all files are revised
+    print(f"\n{str(tmp_path)}\n")
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc_non_standard_filenames",
+    )
+
+    model.title = me.title
+    model.keywords = me.keywords
+
+    output_folder = tmp_path
+    assert output_folder.exists()
+
+    me.revise_manuscript(output_folder, model)
+
+    output_md_files = list(output_folder.glob("*.md"))
+    assert len(output_md_files) == 5

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -887,7 +887,9 @@ And finally, a third sentence so we have more than 2.
     ]
 
     paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
-        paragraph, model, "methods",
+        paragraph,
+        model,
+        "methods",
     )
     assert paragraph_text is not None
     assert paragraph_revised is not None
@@ -1005,7 +1007,9 @@ def test_revise_entire_manuscript_list_of_selected_files_is_empty(tmp_path, mode
         # GPT3CompletionModel(None, None),
     ],
 )
-def test_revise_entire_manuscript_non_standard_filenames_without_custom_prompt(tmp_path, model):
+def test_revise_entire_manuscript_non_standard_filenames_without_custom_prompt(
+    tmp_path, model
+):
     # in this case, the list of selected files is empty and files have non standard names,
     # so none of them are revised
     print(f"\n{str(tmp_path)}\n")
@@ -1030,7 +1034,7 @@ def test_revise_entire_manuscript_non_standard_filenames_without_custom_prompt(t
     "os.environ",
     {
         env_vars.FILENAMES_TO_REVISE: "",
-        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph with manuscript title '{title}': {paragraph_text}"
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph with manuscript title '{title}': {paragraph_text}",
     },
 )
 @pytest.mark.parametrize(
@@ -1040,7 +1044,9 @@ def test_revise_entire_manuscript_non_standard_filenames_without_custom_prompt(t
         # GPT3CompletionModel(None, None),
     ],
 )
-def test_revise_entire_manuscript_non_standard_filenames_with_custom_prompt(tmp_path, model):
+def test_revise_entire_manuscript_non_standard_filenames_with_custom_prompt(
+    tmp_path, model
+):
     # in this case, the list of selected files is empty but there is a custom prompt, so all files are revised
     print(f"\n{str(tmp_path)}\n")
 
@@ -1058,3 +1064,37 @@ def test_revise_entire_manuscript_non_standard_filenames_with_custom_prompt(tmp_
 
     output_md_files = list(output_folder.glob("*.md"))
     assert len(output_md_files) == 5
+
+
+@mock.patch.dict(
+    "os.environ",
+    {env_vars.FILENAMES_TO_REVISE: "", env_vars.CUSTOM_PROMPT: ""},
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        RandomManuscriptRevisionModel(),
+        # GPT3CompletionModel(None, None),
+    ],
+)
+def test_revise_entire_manuscript_non_standard_filenames_with_empty_custom_prompt(
+    tmp_path, model
+):
+    # in this case, the list of selected files is empty and the custom prompt env variable is there but it's empty,
+    # this use case is when the custom prompt is not provided in the workflow interface
+    print(f"\n{str(tmp_path)}\n")
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc_non_standard_filenames",
+    )
+
+    model.title = me.title
+    model.keywords = me.keywords
+
+    output_folder = tmp_path
+    assert output_folder.exists()
+
+    me.revise_manuscript(output_folder, model)
+
+    output_md_files = list(output_folder.glob("*.md"))
+    assert len(output_md_files) == 0

--- a/tests/test_model_basics.py
+++ b/tests/test_model_basics.py
@@ -1,0 +1,256 @@
+"""
+Tests basic functions of the models module that do not require access to an external API.
+"""
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from manubot_ai_editor.editor import ManuscriptEditor, env_vars
+from manubot_ai_editor import models
+from manubot_ai_editor.models import GPT3CompletionModel, RandomManuscriptRevisionModel
+
+MANUSCRIPTS_DIR = Path(__file__).parent / "manuscripts"
+
+
+def test_model_object_init_without_openai_api_key():
+    _environ = os.environ.copy()
+    try:
+        if env_vars.OPENAI_API_KEY in os.environ:
+            os.environ.pop(env_vars.OPENAI_API_KEY)
+
+        with pytest.raises(ValueError):
+            GPT3CompletionModel(
+                title="Test title",
+                keywords=["test", "keywords"],
+            )
+    finally:
+        os.environ = _environ
+
+
+@mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
+def test_model_object_init_with_openai_api_key_as_environment_variable():
+    GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    assert models.openai.api_key == "env_var_test_value"
+
+
+def test_model_object_init_with_openai_api_key_as_parameter():
+    _environ = os.environ.copy()
+    try:
+        if env_vars.OPENAI_API_KEY in os.environ:
+            os.environ.pop(env_vars.OPENAI_API_KEY)
+
+        GPT3CompletionModel(
+            title="Test title",
+            keywords=["test", "keywords"],
+            openai_api_key="test_value",
+        )
+
+        from manubot_ai_editor import models
+
+        assert models.openai.api_key == "test_value"
+    finally:
+        os.environ = _environ
+
+
+@mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
+def test_model_object_init_with_openai_api_key_as_parameter_has_higher_priority():
+    GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+        openai_api_key="test_value",
+    )
+
+    from manubot_ai_editor import models
+
+    assert models.openai.api_key == "test_value"
+
+
+def test_model_object_init_default_language_model():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    assert model.model_parameters["model"] == "text-davinci-003"
+
+
+@mock.patch.dict("os.environ", {env_vars.LANGUAGE_MODEL: "text-curie-001"})
+def test_model_object_init_read_language_model_from_environment():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    assert model.model_parameters["model"] == "text-curie-001"
+
+
+@mock.patch.dict("os.environ", {env_vars.LANGUAGE_MODEL: ""})
+def test_model_object_init_read_language_model_from_environment_is_empty():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    assert model.model_parameters["model"] == "text-davinci-003"
+
+
+def test_get_max_tokens_fraction_is_one():
+    paragraph = r"""
+Correlation coefficients are widely used to identify patterns in data that may be of particular interest.
+In transcriptomics, genes with correlated expression often share functions or are part of disease-relevant biological processes.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    paragraph_text = " ".join(paragraph)
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc",
+    )
+
+    model = GPT3CompletionModel(
+        title=me.title,
+        keywords=me.keywords,
+    )
+
+    max_tokens = model.get_max_tokens(paragraph_text, 1.0)
+    assert max_tokens is not None
+    assert isinstance(max_tokens, int)
+    assert 50 < max_tokens < 60
+
+
+def test_get_max_tokens_using_fraction_is_two():
+    paragraph = r"""
+Correlation coefficients are widely used to identify patterns in data that may be of particular interest.
+In transcriptomics, genes with correlated expression often share functions or are part of disease-relevant biological processes.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    paragraph_text = " ".join(paragraph)
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc",
+    )
+
+    model = GPT3CompletionModel(
+        title=me.title,
+        keywords=me.keywords,
+    )
+
+    max_tokens = model.get_max_tokens(paragraph_text, 2.0)
+    assert max_tokens is not None
+    assert isinstance(max_tokens, int)
+    assert 110 < max_tokens < 120
+
+
+@mock.patch.dict("os.environ", {env_vars.MAX_TOKENS_PER_REQUEST: "0.5"})
+def test_get_max_tokens_using_fraction_is_given_by_environment_and_is_float():
+    paragraph = r"""
+Correlation coefficients are widely used to identify patterns in data that may be of particular interest.
+In transcriptomics, genes with correlated expression often share functions or are part of disease-relevant biological processes.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    paragraph_text = " ".join(paragraph)
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc",
+    )
+
+    model = GPT3CompletionModel(
+        title=me.title,
+        keywords=me.keywords,
+    )
+
+    max_tokens = model.get_max_tokens(paragraph_text)
+    assert max_tokens is not None
+    assert isinstance(max_tokens, int)
+    assert 25 < max_tokens < 35
+
+
+@mock.patch.dict("os.environ", {env_vars.MAX_TOKENS_PER_REQUEST: "779"})
+def test_get_max_tokens_using_fraction_is_given_by_environment_and_is_int():
+    paragraph = r"""
+Correlation coefficients are widely used to identify patterns in data that may be of particular interest.
+In transcriptomics, genes with correlated expression often share functions or are part of disease-relevant biological processes.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    paragraph_text = " ".join(paragraph)
+
+    me = ManuscriptEditor(
+        content_dir=MANUSCRIPTS_DIR / "ccc",
+    )
+
+    model = GPT3CompletionModel(
+        title=me.title,
+        keywords=me.keywords,
+    )
+
+    # parameter 'fraction' is ignored when environment variable is set
+    max_tokens = model.get_max_tokens(paragraph_text, 2.0)
+    assert max_tokens is not None
+    assert isinstance(max_tokens, int)
+    assert max_tokens == 779
+
+
+def test_revise_paragraph_too_few_sentences():
+    # from LLM for articles revision manuscript
+    paragraph = r"""
+Since the gold standard of drug-disease medical indications is described with Disease Ontology IDs (DOID) [@doi:10.1093/nar/gky1032], we mapped PhenomeXcan traits to the Experimental Factor Ontology [@doi:10.1093/bioinformatics/btq099] using [@url:https://github.com/EBISPOT/EFO-UKB-mappings], and then to DOID.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    assert len(paragraph) == 1
+
+    model = RandomManuscriptRevisionModel()
+
+    paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
+        paragraph, model, "methods"
+    )
+    assert paragraph_text is not None
+    assert isinstance(paragraph_text, str)
+
+    assert paragraph_revised is not None
+    assert isinstance(paragraph_revised, str)
+    assert paragraph_revised == paragraph_text
+    assert len(paragraph_revised) > 10
+    assert "<!--\nERROR:" not in paragraph_revised
+
+
+def test_revise_paragraph_too_few_words():
+    # from LLM for articles revision manuscript
+    paragraph = r"""
+We ran our regression model for all 987 LVs across the 4,091 traits in PhenomeXcan.
+For replication, we ran the model in the 309 phecodes in eMERGE.
+We adjusted the $p$-values using the Benjamini-Hochberg procedure.
+    """.strip().split(
+        "\n"
+    )
+    paragraph = [sentence.strip() for sentence in paragraph]
+    assert len(paragraph) == 3
+
+    model = RandomManuscriptRevisionModel()
+
+    paragraph_text, paragraph_revised = ManuscriptEditor.revise_and_write_paragraph(
+        paragraph, model, "methods"
+    )
+    assert paragraph_text is not None
+    assert isinstance(paragraph_text, str)
+
+    assert paragraph_revised is not None
+    assert isinstance(paragraph_revised, str)
+    assert paragraph_revised == paragraph_text
+    assert len(paragraph_revised) > 10
+    assert "<!--\nERROR:" not in paragraph_revised

--- a/tests/test_model_get_prompt.py
+++ b/tests/test_model_get_prompt.py
@@ -4,6 +4,84 @@ from manubot_ai_editor import env_vars
 from manubot_ai_editor.models import GPT3CompletionModel
 
 
+def test_get_prompt_for_abstract():
+    manuscript_title = "Title of the manuscript to be revised"
+    manuscript_keywords = ["keyword0", "keyword1", "keyword2"]
+
+    model = GPT3CompletionModel(
+        title=manuscript_title,
+        keywords=manuscript_keywords,
+    )
+
+    paragraph_text = "Text of the abstract"
+
+    prompt = model.get_prompt(paragraph_text, "abstract")
+    assert prompt is not None
+    assert isinstance(prompt, str)
+    assert "abstract" in prompt
+    assert f"'{manuscript_title}'" in prompt
+    assert f"{manuscript_keywords[0]}" in prompt
+    assert f"{manuscript_keywords[1]}" in prompt
+    assert f"{manuscript_keywords[2]}" in prompt
+    assert paragraph_text in prompt
+    assert prompt.startswith("Revise")
+    assert "  " not in prompt
+
+
+def test_get_prompt_for_abstract_edit_endpoint():
+    manuscript_title = "Title of the manuscript to be revised"
+    manuscript_keywords = ["keyword0", "keyword1", "keyword2"]
+
+    model = GPT3CompletionModel(
+        title=manuscript_title,
+        keywords=manuscript_keywords,
+        model_engine="text-davinci-edit-001",
+    )
+
+    paragraph_text = "Text of the abstract. "
+
+    instruction, paragraph = model.get_prompt(paragraph_text, "abstract")
+    assert instruction is not None
+    assert isinstance(instruction, str)
+    assert paragraph is not None
+    assert isinstance(paragraph, str)
+
+    assert "this paragraph" in instruction
+    assert "abstract" in instruction
+    assert f"'{manuscript_title}'" in instruction
+    assert f"{manuscript_keywords[0]}" in instruction
+    assert f"{manuscript_keywords[1]}" in instruction
+    assert f"{manuscript_keywords[2]}" in instruction
+    assert "  " not in instruction
+    assert instruction.startswith("Revise")
+
+    assert paragraph_text.strip() == paragraph
+
+
+def test_get_prompt_for_introduction():
+    manuscript_title = "Title of the manuscript to be revised"
+    manuscript_keywords = ["keyword0", "keyword1", "keyword2"]
+
+    model = GPT3CompletionModel(
+        title=manuscript_title,
+        keywords=manuscript_keywords,
+    )
+
+    paragraph_text = "Text of the initial part"
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert prompt is not None
+    assert isinstance(prompt, str)
+    assert "Introduction" in prompt
+    assert f"'{manuscript_title}'" in prompt
+    assert f"{manuscript_keywords[0]}" in prompt
+    assert f"{manuscript_keywords[1]}" in prompt
+    assert f"{manuscript_keywords[2]}" in prompt
+    assert paragraph_text in prompt
+    assert prompt.startswith("Revise")
+    assert "  " not in prompt
+
+
 def test_get_prompt_section_is_abstract():
     model = GPT3CompletionModel(
         title="Test title",

--- a/tests/test_model_get_prompt.py
+++ b/tests/test_model_get_prompt.py
@@ -4,6 +4,25 @@ from manubot_ai_editor import env_vars
 from manubot_ai_editor.models import GPT3CompletionModel
 
 
+def test_get_prompt_section_is_abstract():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "abstract")
+    assert prompt.startswith(
+        "Revise the following paragraph from the abstract of an academic paper "
+    )
+    assert prompt.endswith(paragraph_text[-20:])
+
+
 def test_get_prompt_section_is_introduction():
     model = GPT3CompletionModel(
         title="Test title",
@@ -17,7 +36,28 @@ Finally, the third sentence.
     """.strip()
 
     prompt = model.get_prompt(paragraph_text, "introduction")
-    assert prompt.startswith("Revise the following paragraph from the Introduction ")
+    assert prompt.startswith(
+        "Revise the following paragraph from the Introduction section "
+    )
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_section_is_discussion():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "discussion")
+    assert prompt.startswith(
+        "Revise the following paragraph from the Discussion section "
+    )
     assert prompt.endswith(paragraph_text[-20:])
 
 
@@ -35,6 +75,63 @@ Finally, the third sentence.
 
     prompt = model.get_prompt(paragraph_text, "methods")
     assert prompt.startswith("Revise the paragraph(s) below from the Methods ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_section_is_results():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "results")
+    assert prompt.startswith("Revise the following paragraph from the Results section ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_not_standard_section():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "acknowledgements")
+    assert prompt.startswith(
+        "Revise the following paragraph from the Acknowledgements section of an academic paper "
+        "(with title 'Test title' and keywords 'test, keywords') so the text "
+    )
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_section_not_provided():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text)
+    assert prompt.startswith(
+        "Revise the following paragraph of an academic paper "
+        "(with title 'Test title' and keywords 'test, keywords') so the text "
+    )
     assert prompt.endswith(paragraph_text[-20:])
 
 

--- a/tests/test_model_get_prompt.py
+++ b/tests/test_model_get_prompt.py
@@ -1,0 +1,182 @@
+from unittest import mock
+
+from manubot_ai_editor import env_vars
+from manubot_ai_editor.models import GPT3CompletionModel
+
+
+def test_get_prompt_section_is_introduction():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert prompt.startswith("Revise the following paragraph from the Introduction ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_section_is_methods():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "methods")
+    assert prompt.startswith("Revise the paragraph(s) below from the Methods ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+def test_get_prompt_section_is_none():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text)
+    assert prompt.startswith("Revise the following paragraph of an academic paper ")
+    assert prompt.endswith(paragraph_text[-20:])
+
+
+@mock.patch.dict(
+    "os.environ",
+    {env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph"},
+)
+def test_get_prompt_custom_prompt_no_placeholders():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt == f"proofread and revise the following paragraph:\n\n{paragraph_text}"
+    )
+
+    prompt = model.get_prompt(paragraph_text, "methods")
+    assert (
+        prompt == f"proofread and revise the following paragraph:\n\n{paragraph_text}"
+    )
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph from the {section_name} section"
+    },
+)
+def test_get_prompt_custom_prompt_with_section_name():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt
+        == f"proofread and revise the following paragraph from the introduction section:\n\n{paragraph_text}"
+    )
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph of a manuscript with title '{title}'"
+    },
+)
+def test_get_prompt_custom_prompt_with_manuscript_title():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt
+        == f"proofread and revise the following paragraph of a manuscript with title 'Test title':\n\n{paragraph_text}"
+    )
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph of a manuscript with title '{title}' and keywords '{keywords}'"
+    },
+)
+def test_get_prompt_custom_prompt_with_manuscript_title_and_keywords():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt
+        == f"proofread and revise the following paragraph of a manuscript with title 'Test title' and keywords 'test, keywords':\n\n{paragraph_text}"
+    )
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        env_vars.CUSTOM_PROMPT: "proofread and revise the following paragraph from the {section_name} section: {paragraph_text}"
+    },
+)
+def test_get_prompt_custom_prompt_with_paragraph_text():
+    model = GPT3CompletionModel(
+        title="Test title",
+        keywords=["test", "keywords"],
+    )
+
+    paragraph_text = """
+This is the first sentence.
+And this is the second sentence.
+Finally, the third sentence.
+    """.strip()
+
+    prompt = model.get_prompt(paragraph_text, "introduction")
+    assert (
+        prompt
+        == f"proofread and revise the following paragraph from the introduction section: {paragraph_text}"
+    )


### PR DESCRIPTION
This PR adds basic support for custom prompts. The documentation was added as part of [this manubot/rootstock PR](https://github.com/manubot/rootstock/pull/496).

In general, the code of this repo needs refactoring. This change is already part of a [release in PyPI](https://pypi.org/project/manubot-ai-editor/), and therefore is the code used when any user is running the `ai-revision` workflow. This was done so I could test it in GitHub Actions, but we probably need another, safer release mechanism.