### PR TITLE
Custom Prompts Example Config, Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,6 @@ In order to revise your manuscript, prompts must be provided to the AI model. Th
 - **Default prompts**: you can use the default prompts provided by the tool, in which case you don't need to do anything.
 - **Custom prompts**: you can define your own prompts to apply to specific files using YAML configuration files that you include with your manuscript.
 
-The default prompt, which should work for most manuscripts, is the following:
-
-```
-Proofread the following paragraph that is part of a scientific manuscript.
-Keep all Markdown formatting, citations to other articles, mathematical expressions, and equations.
-```
-
 If you wish to customize the prompts on a per-file basis, see [docs/custom-prompts.md](docs/custom-prompts.md) for more information.
 
 ### Command line

--- a/docs/custom-prompts.md
+++ b/docs/custom-prompts.md
@@ -12,6 +12,8 @@ These files should be placed in the `content` directory alongside your manuscrip
 
 See [Functionality Notes](#functionality-notes) later in this document for more information on how to write regular expressions and use placeholders in your prompts.
 
+See [Example Configuration](#example-configuration) for a quick guide on how to enable the custom prompts system.
+
 ## Approach 1: Single file
 
 With this approach, you can define your prompts and how they map to your manuscript files in a single file.
@@ -87,6 +89,14 @@ In this case, the `default_prompt` is used when no other regex matches, and it u
 
 The `ignores` list specifies files that should be skipped entirely during the revision process; they won't have the default prompt applied to them.
 
+## Example Configuration
+
+You can find an example of the `ai-revision_prompts.yaml` and `ai-revision_config.yaml` files in the `docs/example` directory of this repository.
+
+The prompts file, [`docs/example/ai-revision_prompts.yaml`](docs/example/ai-revision_prompts.yaml), contains some example prompts as well as a default prompt.
+The config file, [`docs/example/ai-revision_config.yaml`](docs/example/ai-revision_config.yaml), maps all `.md` files to the prompt with the identifier `default`.
+
+You can copy these two files into your manuscript's `content` directory to start using the custom prompts system, then modify them to suit your needs.
 
 ## Functionality Notes
 

--- a/docs/example/ai-revision_config.yaml
+++ b/docs/example/ai-revision_config.yaml
@@ -1,0 +1,5 @@
+files:
+  matchings:
+    - files:
+        - .*\.md$
+      prompt: default

--- a/docs/example/ai-revision_prompts.yaml
+++ b/docs/example/ai-revision_prompts.yaml
@@ -1,0 +1,43 @@
+prompts:
+  abstract: |
+    You are a scientist with copy-editing skills who will help in improving the
+    text of a manuscript. Revise the following abstract of this manuscript so
+    that it has a clear sentence structure and fits in a single paragraph. The
+    revision should follow a context-content-conclusion (C-C-C) scheme, as
+    follows: 1) The context portion communicates to the reader what gap the
+    paper will fill. The first sentence orients the reader by introducing the
+    broader field in which the manuscript's research is situated. Then, the
+    context is narrowed until it lands on the open question that the research
+    answers. A successful context section distinguishes the research's
+    contributions from the current state-of-the-art, communicating what is
+    missing in the current literature (i.e., the specific gap) and why that
+    matters (i.e. the connection between the specific gap and the broader
+    context). 2) The content portion (e.g. "here we") first describes the novel
+    method or approach that was used to fill the gap, then presents an executive
+    summary of results. 3) The conclusion portion interprets the results to
+    answer the question that was posed at the end of the context portion. There
+    may be a second part to the conclusion portion that highlights how this
+    conclusion moves the broader field forward (e.g. "broader significance").
+
+  introduction: |
+    You are a scientist with copy-editing skills tasked with refining the text
+    of a scientific manuscript. Your goal is to revise the following paragraph
+    from the Introduction section to enhance clarity, reduce jargon, and
+    maintain a scholarly tone. The revision should adhere to Markdown formatting
+    and follow a Context-Content-Conclusion (C-C-C) structure. This structure
+    begins by setting the stage with one or two sentences (Context), progresses
+    through what is known from the literature (Content), and concludes by
+    highlighting an aspect of the knowledge gap the manuscript addresses
+    (Conclusion). Your revision should: 1) preserve the original information as
+    much as possible, with minimal changes to the text, 2) ensure most
+    references to scientific articles are kept exactly as they appear in the
+    original text; these references are crucial for academic integrity and may
+    appear with the format "[@TYPE:ID]" such as "[@pmid:33931583;
+    @doi:10.1101/2021.10.21.21265225; @pmid:31036433]", and 4) the revised
+    paragraph must encapsulate the entire revision, following the C-C-C
+    structure, within a single, cohesive paragraph.
+
+  default: |
+    Proofread the following paragraph that is part of a scientific manuscript.
+    Keep all Markdown formatting, citations to other articles, mathematical
+    expressions, and equations.

--- a/libs/manubot_ai_editor/prompt_config.py
+++ b/libs/manubot_ai_editor/prompt_config.py
@@ -176,7 +176,7 @@ class ManuscriptPromptConfig:
         resolved_default_prompt = None
         if use_default and self.prompts is not None:
             resolved_default_prompt = self.prompts.get(
-                get_obj_path(self.config, ("files", "default_prompt"), missing="default"),
+                get_obj_path(self.config, ("files", "default_prompt")),
                 None
             )
 


### PR DESCRIPTION
This PR adds the following:
- example `ai-revision_config.yaml` and `ai-revision_prompts.yaml` files
  - the `_prompts.yaml` file includes the intro and abstract prompts from https://github.com/pivlab/manubot-ai-editor-evals and the default prompt from @miltondp 
  - the `_config.yaml` file is only configured to map `.md` files to the `default` prompt

Other changes:
- Fixed an issue in the custom prompts system where not specifying the `files.default_prompt` value would always resort to returning `"default"` rather than returning `None`. With this change, it's now possible to bypass the custom prompts system when no explicit filename matches are found, allowing [default prompt resolution](https://github.com/manubot/manubot-ai-editor/blob/main/libs/manubot_ai_editor/models.py#L320-L379) to take place.
- removed the default prompt from `README.md`, as it's now provided in the example config rather than hardcoded, and will later be provided in a default `ai-revision_prompts.yaml` file in [manubot/rootstock](https://github.com/manubot/rootstock).