### PR TITLE
Widens missing OpenAI API key check to include blank strings

### DIFF
--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -146,7 +146,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
         if openai.api_key is None:
             openai.api_key = os.environ.get(env_vars.OPENAI_API_KEY, None)
 
-            if openai.api_key is None:
+            if openai.api_key is None or openai.api_key.strip() == "":
                 raise ValueError(
                     f"OpenAI API key not found. Please provide it as parameter "
                     f"or set it as an the environment variable "


### PR DESCRIPTION
This PR widens the check for a missing `OPENAI_API_KEY` env var to when that env var is a blank string, which I believe happens when repo in which the AI revision GitHub workflow runs doesn't have the `OPENAI_API_KEY` secret registered. See here: https://github.com/CU-DBMI/rootstock/blob/main/.github/workflows/ai-revision.yaml#L59.

After this PR, the error message will be "OpenAI API key not found. Please provide it as parameter or set it as an the environment variable OPENAI_API_KEY". Let me know if that's informative enough, or if it should be updated.

Closes #45.