### PR TITLE
Add automated testing for `pytest` through GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,35 @@
+---
+name: run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run_tests:
+    strategy:
+      matrix:
+        # matrixed execution for parallel gh-action performance increases
+        python_version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-22.04, macos-13]
+    runs-on: ${{ matrix.os }}
+    env:
+      OS: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Setup python env
+        run: |
+          pip install pytest
+          pip install .
+      - name: Run pytest
+        env:
+          # set a placeholder OpenAI key (required by tests)
+          OPENAI_API_KEY: ABCD1234
+        run: python -m pytest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[milton.pividori@cuanschutz.edu](mailto:milton.pividori@cuanschutz.edu).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+First of all, thank you so much for contributing! 🎉 💯
+
+This document contains guidelines on how to most effectively contribute within this repository.
+
+If you are stuck, please feel free to ask any questions or ask for help.
+
+## Code of conduct
+
+This project is governed by our [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Development
+
+This project leverages development environments managed by a Python [`setup.py` file.](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#setup-py)
+We use [pytest](https://docs.pytest.org/) for testing and [GitHub Actions](https://docs.github.com/en/actions) for automated tests.
+[`pre-commit`](https://pre-commit.com/) is used to help lint or format code.
+A [Conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) is provided (via the file `environment.yml`) for convenience but is not required for development purposes.
+
+### Development setup
+
+Perform the following steps to setup a Python development environment.
+
+1. [Install Python](https://www.python.org/downloads/) (we recommend using [`pyenv`](https://github.com/pyenv/pyenv) or similar)
+1. Install package, e.g. `pip install .` (from the root directory, referencing the `setup.py`)
+1. Install pytest: `pip install pytest`
+
+### Linting
+
+Work added to this project is automatically checked using [pre-commit](https://pre-commit.com/) via [GitHub Actions](https://docs.github.com/en/actions).
+Pre-commit can work alongside your local [git with git-hooks](https://pre-commit.com/index.html#3-install-the-git-hook-scripts)
+
+After [installing pre-commit](https://pre-commit.com/#installation) within your development environment, the following command also can perform the same checks within your local development environment:
+
+```sh
+% pre-commit run --all-files
+```
+
+We use these same checks within our automated tests which are managed by [GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows).
+These automated tests generally must pass in order to merge work into this repository.
+
+### Testing
+
+Work added to this project is automatically tested using [pytest](https://docs.pytest.org/) via [GitHub Actions](https://docs.github.com/en/actions).
+Pytest is installed through the Poetry environment for this project.
+We recommend testing your work before opening pull requests with proposed changes.
+
+You can run pytest on your work using the following example:
+
+```sh
+% python -m pytest
+```
+
+## Making changes to this repository
+
+We welcome anyone to use [GitHub issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) (requires a GitHub login) or create [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) (to directly make changes within this repository) to modify content found within this repository.
+
+Specifically, there are several ways to suggest or make changes to this repository:
+
+1. Open a GitHub issue: https://github.com/manubot/manubot-ai-editor/issues
+1. Create a pull request from a forked branch of the repository
+
+### Creating a pull request
+
+### Pull requests
+
+After you’ve decided to contribute code and have written it up, please file a pull request.
+We specifically follow a [forked pull request model](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+Please create a fork of this repository, clone the fork, and then create a new, feature-specific branch.
+Once you make the necessary changes on this branch, you should file a pull request to incorporate your changes into this (fork upstream) repository.
+
+The content and description of your pull request are directly related to the speed at which we are able to review, approve, and merge your contribution.
+To ensure an efficient review process please perform the following steps:
+
+1. Triple check that your pull request is adding _one_ specific feature or additional group of content.
+   Small, bite-sized pull requests move so much faster than large pull requests.
+1. After submitting your pull request, ensure that your contribution passes all status checks (e.g. passes all tests)
+
+Pull request review and approval is required by at least one project maintainer to merge.
+We will do our best to review the code addition in a timely fashion.
+Ensuring that you follow all steps above will increase our speed and ability to review.
+We will check for accuracy, style, code coverage, and scope.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,7 @@ me.revise_manuscript(output_folder, model)
 ```
 
 The [`cli_process` function in this file](https://github.com/manubot/manubot/blob/f62dd4cfdebf67f99f63c9b2e64edeaa591eeb69/manubot/ai_revision/ai_revision_command.py#L7) provides another example of how to use the API.
+
+## Development and Contributions
+
+Please see our [CONTRIBUTING.md](CONTRIBUTING.md) guide for more information on developing this project or making a contributon.


### PR DESCRIPTION
This PR adds automated testing for `pytest` through GitHub Actions on PR and push to the `main` branch as a prerequisite of #52. These tests have a chance of not running on this PR due to this being my first contribution to this repository (a GitHub security constraint). I've attempted to test this workflow as best as possible (manually, as attempting to use [`act`](https://github.com/nektos/act) resulted in errors related to https://github.com/actions/setup-python/issues/401).

While I was working through this I noticed there was no `CONTRIBUTING.md` or `CODE_OF_CONDUCT.md`. I've added these with some template information that has been slightly modified to meet the needs here.

Please don't hesitate to let me know if you have any questions - look forward to any feedback you may have!

Closes #53 