### PR TITLE
Langchain Integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ setuptools.setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        # "openai==0.28",
-        "openai==1.48.0",
-        # "langchain-openai==0.2.0",
+        "langchain-openai==0.2.0",
         "pyyaml",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
     python_requires=">=3.10",
     install_requires=[
         # "openai==0.28",
-        "langchain-openai==0.2.0",
+        "openai==1.48.0",
+        # "langchain-openai==0.2.0",
         "pyyaml",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="manubot-ai-editor",
-    version="0.5.2",
+    version="0.5.3",
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="A Manubot plugin to revise a manuscript using GPT-3",
@@ -25,7 +25,8 @@ setuptools.setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "openai==0.28",
+        # "openai==0.28",
+        "langchain-openai==0.2.0",
         "pyyaml",
     ],
     classifiers=[

--- a/tests/test_model_basics.py
+++ b/tests/test_model_basics.py
@@ -9,7 +9,6 @@ from unittest import mock
 import pytest
 
 from manubot_ai_editor.editor import ManuscriptEditor, env_vars
-from manubot_ai_editor import models
 from manubot_ai_editor.models import GPT3CompletionModel, RandomManuscriptRevisionModel
 
 MANUSCRIPTS_DIR = Path(__file__).parent / "manuscripts"
@@ -37,7 +36,7 @@ def test_model_object_init_with_openai_api_key_as_environment_variable():
         keywords=["test", "keywords"],
     )
 
-    assert model.client.api_key == "env_var_test_value"
+    assert model.client.openai_api_key.get_secret_value() == "env_var_test_value"
 
 
 def test_model_object_init_with_openai_api_key_as_parameter():
@@ -52,7 +51,7 @@ def test_model_object_init_with_openai_api_key_as_parameter():
             openai_api_key="test_value",
         )
 
-        assert model.client.api_key == "test_value"
+        assert model.client.openai_api_key.get_secret_value() == "test_value"
     finally:
         os.environ = _environ
 
@@ -65,7 +64,7 @@ def test_model_object_init_with_openai_api_key_as_parameter_has_higher_priority(
         openai_api_key="test_value",
     )
 
-    assert model.client.api_key == "test_value"
+    assert model.client.openai_api_key.get_secret_value() == "test_value"
 
 
 def test_model_object_init_default_language_model():

--- a/tests/test_model_basics.py
+++ b/tests/test_model_basics.py
@@ -32,12 +32,12 @@ def test_model_object_init_without_openai_api_key():
 
 @mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
 def test_model_object_init_with_openai_api_key_as_environment_variable():
-    GPT3CompletionModel(
+    model = GPT3CompletionModel(
         title="Test title",
         keywords=["test", "keywords"],
     )
 
-    assert models.openai.api_key == "env_var_test_value"
+    assert model.client.api_key == "env_var_test_value"
 
 
 def test_model_object_init_with_openai_api_key_as_parameter():
@@ -46,30 +46,26 @@ def test_model_object_init_with_openai_api_key_as_parameter():
         if env_vars.OPENAI_API_KEY in os.environ:
             os.environ.pop(env_vars.OPENAI_API_KEY)
 
-        GPT3CompletionModel(
+        model = GPT3CompletionModel(
             title="Test title",
             keywords=["test", "keywords"],
             openai_api_key="test_value",
         )
 
-        from manubot_ai_editor import models
-
-        assert models.openai.api_key == "test_value"
+        assert model.client.api_key == "test_value"
     finally:
         os.environ = _environ
 
 
 @mock.patch.dict("os.environ", {env_vars.OPENAI_API_KEY: "env_var_test_value"})
 def test_model_object_init_with_openai_api_key_as_parameter_has_higher_priority():
-    GPT3CompletionModel(
+    model = GPT3CompletionModel(
         title="Test title",
         keywords=["test", "keywords"],
         openai_api_key="test_value",
     )
 
-    from manubot_ai_editor import models
-
-    assert models.openai.api_key == "test_value"
+    assert model.client.api_key == "test_value"
 
 
 def test_model_object_init_default_language_model():


### PR DESCRIPTION
This (work-in-progress) PR changes the `GPT3CompletionModel` from using the `openai` package directly for communicating with the OpenAI API to using `langchain-openai`, which wraps the `openai` package.

Tests have been updated and should work with LangChain. Executing `pytest --runcost` will actually query the OpenAI API, so that should be considered a good test that the changeover to the new package is working.

There's still many things missing (e.g.. mapping all the `openai` params to LangChain equivalents), which is why this PR is a draft, but I thought I'd push it early and get comments as we incrementally make the change to LangChain.