### PR TITLE
Enable poetry dynamic versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,14 @@ Pull request review and approval is required by at least one project maintainer 
 We will do our best to review the code addition in a timely fashion.
 Ensuring that you follow all steps above will increase our speed and ability to review.
 We will check for accuracy, style, code coverage, and scope.
+
+## Versioning
+
+We use [`poetry-dynamic-versioning`](https://github.com/mtkennerly/poetry-dynamic-versioning) to help version this software through [`PEP 440`](https://peps.python.org/pep-0440/) standards.
+Configuration for versioning is found within the `pyproject.toml` file.
+All builds for packages include dynamic version data to help label distinct versions of the software.
+`poetry-dynamic-versioning` uses `git` tags to help distinguish version data.
+We also use the `__init__.py` file as a place to persist the version data for occaissions where the `git` history is unavailable or unwanted.
+
+The following command is used to add `poetry-dynamic-versioning` to Poetry for use with this project: `poetry self add "poetry-dynamic-versioning[plugin]"`.
+Versioning for the project is intended to align with GitHub Releases which provide `git` tag capabilities.

--- a/libs/manubot_ai_editor/__init__.py
+++ b/libs/manubot_ai_editor/__init__.py
@@ -1,0 +1,6 @@
+"""
+Init file for manubot_ai_editor
+"""
+
+# note: version data is maintained by poetry-dynamic-versioning (do not edit)
+__version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-build-backend = "poetry.core.masonry.api"
-requires = [ "poetry-core>=1" ]
+build-backend = "poetry_dynamic_versioning.backend"
+requires = [ "poetry-core>=1", "poetry-dynamic-versioning>=1,<2" ]
 
 [tool.poetry]
 name = "manubot-ai-editor"
-version = "0.5.2"
+# note: version data is maintained by poetry-dynamic-versioning (do not edit)
+version = "0.0.0"
 description = "A Manubot plugin to revise a manuscript using GPT-3"
 authors = [ "Milton Pividori <miltondp@gmail.com>" ]
 maintainers = [
@@ -32,6 +33,12 @@ pyyaml = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.3.3"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+style = "pep440"
+vcs = "git"
+substitution.files = [ "libs/manubot_ai_editor/__init__.py" ]
 
 [tool.setuptools_scm]
 root = "."


### PR DESCRIPTION
This PR enables [poetry dynamic versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) to enhance how packages may be built and labeled for distribution. I also added a dunder variable to the primary init file in order to make the version accessible within the package itself (often useful in scenarios where the version data may otherwise be unavailable through Python).

Thanks for any feedback!

References #52 (step 2)