### PR TITLE
Add `release-drafter` workflow and configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+---
+# template configuration for release-drafter
+# see: https://github.com/release-drafter/release-drafter
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - 'release-major'
+  minor:
+    labels:
+      - 'release-minor'
+  patch:
+    labels:
+      - 'release-patch'
+  default: patch
+change-template: '- $TITLE (@$AUTHOR via #$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,23 @@
+---
+# workflow for drafting releases on GitHub
+# see: https://github.com/release-drafter/release-drafter
+name: release drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  draft_release:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,3 +103,22 @@ We also use the `__init__.py` file as a place to persist the version data for oc
 
 The following command is used to add `poetry-dynamic-versioning` to Poetry for use with this project: `poetry self add "poetry-dynamic-versioning[plugin]"`.
 Versioning for the project is intended to align with GitHub Releases which provide `git` tag capabilities.
+
+### Releases
+
+We publish source code by using [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) available [here](https://github.com/manubot/manubot-ai-editor/releases).
+We publish a related Python package through the [Python Packaging Index (PyPI)](https://pypi.org/) available [here](https://pypi.org/project/manubot-ai-editor/).
+
+#### Release Publishing Process
+
+Several manual and automated steps are involved with publishing manubot-ai-editor releases.
+See below for an overview of how this works.
+
+Notes about [semantic version](https://en.wikipedia.org/wiki/Software_versioning#Semantic_versioning) (semver) specifications:
+manubot-ai-editor version specifications are controlled through [`poetry-dynamic-versioning`](https://github.com/mtkennerly/poetry-dynamic-versioning) which leverages [`dunamai`](https://github.com/mtkennerly/dunamai) to create version data based on [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) and commits.
+manubot-ai-editor release git tags are automatically applied through [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) and related inferred changes from [`release-drafter`](https://github.com/release-drafter/release-drafter).
+
+1. Open a pull request and use a repository label for `release-<semver release type>` to label the pull request for visibility with [`release-drafter`](https://github.com/release-drafter/release-drafter).
+1. On merging the pull request for the release, a [GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows) defined in `draft-release.yml` leveraging [`release-drafter`](https://github.com/release-drafter/release-drafter) will draft a release for maintainers.
+1. The draft GitHub release will include a version tag based on the GitHub PR label applied and `release-drafter`.
+1. Make modifications as necessary to the draft GitHub release, then publish the release (the draft release does not require additional modifications by default).


### PR DESCRIPTION
This PR adds a [`release-drafter`](https://github.com/release-drafter/release-drafter) workflow and configuration for the project as part of #52 . After this is merged, each merged PR will add to a GitHub release draft which documents the changes and readies the changes for a non-draft release. Before this is merged we would need to create the tags outlined in the configuration file (`release-drafter.yml`).

Should be merged after #69 

References #52 