### PR TITLE
Add PyPI trusted publisher workflow for automated package releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,37 @@
+---
+# used for publishing packages to pypi on release
+name: publish pypi release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish_pypi:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --all --tags
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Setup for poetry
+        run: |
+          python -m pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
+      - name: Install environment
+        run: poetry install --no-interaction --no-ansi
+      - name: poetry build distribution content
+        run: poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,4 @@ manubot-ai-editor release git tags are automatically applied through [GitHub Rel
 1. On merging the pull request for the release, a [GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows) defined in `draft-release.yml` leveraging [`release-drafter`](https://github.com/release-drafter/release-drafter) will draft a release for maintainers.
 1. The draft GitHub release will include a version tag based on the GitHub PR label applied and `release-drafter`.
 1. Make modifications as necessary to the draft GitHub release, then publish the release (the draft release does not require additional modifications by default).
+1. On publishing the GitHub release, another GitHub Actions workflow defined in `publish-pypi.yml` will run to build and deploy the Python package to PyPI (utilizing the earlier modified `pyproject.toml` semantic version reference for labeling the release).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,6 @@ Specifically, there are several ways to suggest or make changes to this reposito
 1. Open a GitHub issue: https://github.com/manubot/manubot-ai-editor/issues
 1. Create a pull request from a forked branch of the repository
 
-### Creating a pull request
-
 ### Pull requests
 
 After you’ve decided to contribute code and have written it up, please file a pull request.
@@ -92,3 +90,17 @@ Pull request review and approval is required by at least one project maintainer 
 We will do our best to review the code addition in a timely fashion.
 Ensuring that you follow all steps above will increase our speed and ability to review.
 We will check for accuracy, style, code coverage, and scope.
+
+#### Release publishing process
+
+Several manual and automated steps are involved with publishing `manubot-ai-editor` releases.
+See below for an overview of how this works.
+
+Notes about [semantic version](https://en.wikipedia.org/wiki/Software_versioning#Semantic_versioning) (semver) specifications:
+`manubot-ai-editor` version specifications are controlled through [`poetry-dynamic-versioning`](https://github.com/mtkennerly/poetry-dynamic-versioning) which leverages [`dunamai`](https://github.com/mtkennerly/dunamai) to create version data based on [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) and commits.
+`manubot-ai-editor` release git tags are automatically applied through [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) and related inferred changes from [`release-drafter`](https://github.com/release-drafter/release-drafter).
+
+1. Open a pull request and use a repository label for `release-<semver release type>` to label the pull request for visibility with [`release-drafter`](https://github.com/release-drafter/release-drafter). On merging the pull request for the release, a [GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows) defined in `draft-release.yml` leveraging [`release-drafter`](https://github.com/release-drafter/release-drafter) will draft a release for maintainers.
+1. The draft GitHub release will include a version tag based on the GitHub PR label applied and `release-drafter`.
+1. Make modifications as necessary to the draft GitHub release, then publish the release (the draft release does not normally need additional modifications).
+1. On publishing the release, another GitHub Actions workflow defined in `publish-pypi.yml` will run to build and deploy the Python package to PyPI (utilizing the earlier modified `pyproject.toml` semantic version reference for labeling the release).


### PR DESCRIPTION
This PR adds a [trusted publisher workflow](https://docs.pypi.org/trusted-publishers/) for this project to automate the release of PyPI packages. The docs for the process including other steps from #72, #69 are also included here.

Should be merged after #72 

Closes #52 