### PR TITLE
Create project `CITATION.cff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,7 @@ repos:
     rev: v1.7.3
     hooks:
       - id: actionlint
+  - repo: https://github.com/citation-file-format/cffconvert
+    rev: b6045d78aac9e02b039703b030588d54d53262ac
+    hooks:
+      - id: validate-cff

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ authors:
   - given-names: Vincent
     family-names: Rubinetti
     orcid: "https://orcid.org/0000-0002-4655-3773"
-  - given-names: David
+  - given-names: Dave
     family-names: Bunten
     orcid: "https://orcid.org/0000-0001-6041-3665"
   - given-names: Casey

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,40 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+---
+cff-version: 1.2.0
+title: Manubot AI Editor
+message: >-
+  If you use this work in some way, please consider
+  citing it using the metadata from this file.
+type: software
+authors:
+  - given-names: Milton
+    family-names: Pividori
+    orcid: "https://orcid.org/0000-0002-3035-4403"
+  - given-names: Faisal
+    family-names: Alquaddoomi
+    orcid: "https://orcid.org/0000-0003-4297-8747"
+  - given-names: Vincent
+    family-names: Rubinetti
+    orcid: "https://orcid.org/0000-0002-4655-3773"
+  - given-names: David
+    family-names: Bunten
+    orcid: "https://orcid.org/0000-0001-6041-3665"
+  - given-names: Casey
+    family-names: Greene
+    orcid: "https://orcid.org/0000-0001-8713-9213"
+repository-code: "https://github.com/manubot/manubot-ai-editor"
+abstract: |
+  A tool for performing automatic, AI-assisted revisions of Manubot manuscripts.
+keywords:
+  - Manubot
+  - AI
+  - Editor
+  - Manuscript
+  - Revision
+  - Research
+license: BSD-3-Clause
+identifiers:
+  - description: Manuscript
+    type: doi
+    value: "10.1093/jamia/ocae139"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,12 +27,13 @@ repository-code: "https://github.com/manubot/manubot-ai-editor"
 abstract: |
   A tool for performing automatic, AI-assisted revisions of Manubot manuscripts.
 keywords:
-  - Manubot
+  - manubot
   - AI
-  - Editor
-  - Manuscript
-  - Revision
-  - Research
+  - editor
+  - manuscript
+  - revision
+  - research
+  - large-language-models
 license: BSD-3-Clause
 identifiers:
   - description: Manuscript


### PR DESCRIPTION
This PR adds a project `CITATION.cff` which provides citation materials in a structured format which is compatible with many other systems (including GitHub). As part of this I made a guess at the authors who should be included - please don't hesitate to suggest a different order or let me know if I need to change something in specific. I also added a new pre-commit check which ensures this file follows the correct schema.

Thanks for any feedback!

Closes #77 