### PR TITLE
Fixes outdated pre-commit hook introduced in PR 62

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # This hook checks yaml files for parseable syntax.
     -   id: check-yaml
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.9.6
     hooks:
     -   id: ruff
         args:


### PR DESCRIPTION
PR #62 was previously merged today, but it wasn't up-to-date with the changes to pre-commit hooks from main, and thus the pre-commit-upgrade check had failed due to ruff-pre-commit being out of date. Unfortunately I had already merged that PR, so I couldn't apply the recommendation from the check.

I've opened up this tiny PR that bumps ruff and should fix the failing check.