### PR TITLE
Adds provider, model vars docs to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: poetry-check
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.1"
+    rev: "v2.6.0"
     hooks:
     -   id: pyproject-fmt
 -   repo: https://github.com/rhysd/actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     -   id: black
         language_version: python3
 -   repo: https://github.com/python-poetry/poetry
-    rev: "2.1.2"
+    rev: "2.1.3"
     hooks:
     -   id: poetry-check
 -   repo: https://github.com/tox-dev/pyproject-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # This hook checks yaml files for parseable syntax.
     -   id: check-yaml
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.8
     hooks:
     -   id: ruff
         args:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Start with a manuscript repo [forked from Manubot rootstock](https://github.com/
 1. If you haven't already, follow the directions above to create an account and get an API key for your chosen model provider.
 1. In your fork's "⚙️ Settings" tab, make a new Actions repository secret with the name `PROVIDER_API_KEY` and paste in your API key as the secret.
 
-If you prefer to select fewer options when running the workflow, you can optionally set up default values for the
-model provider and model at either the repo or organization level.
+If you prefer to select less options when running the workflow, you can optionally set up default values for the model provider and model at either the repo or organization level.
 
 In your fork's "⚙️ Settings" tab you can optionally create the following Actions repository variables:
 - `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets  the default if "(repo default)" was selected
@@ -51,10 +50,8 @@ In your fork's "⚙️ Settings" tab you can optionally create the following Act
 
 ### Multiple Providers
 
-In case you want to use several providers in the same repo, you'll have to register an API key for each provider you
-intend to use.
-Like `PROVIDER_API_KEY`, these keys are also registered as GitHub secrets, and can be specified at either the repository or
-organizational level.
+In case you want to use several providers in the same repo, you'll have to register an API key for each provider you intend to use.
+Like `PROVIDER_API_KEY`, these keys are also registered as GitHub secrets, and can be specified at either the repository or organizational level.
 
 We currently support the following secrets, with more to follow as we integrate more providers:
 - `OPENAI_API_KEY`: the API key for the "openai" provider

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ Start with a manuscript repo [forked from Manubot rootstock](https://github.com/
 1. If you haven't already, follow the directions above to create an account and get an API key for your chosen model provider.
 1. In your fork's "⚙️ Settings" tab, make a new Actions repository secret with the name `PROVIDER_API_KEY` and paste in your API key as the secret.
 
+If you prefer to select less options when running the workflow, you can optionally set up default values for the
+model provider and model at either the repo or organization level.
+
+In your fork's "⚙️ Settings" tab, you can optionally create the folllowing Actions repository variables:
+- `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets this as the default if "(repo default)" was selected
+  in the workflow parameters. If this is unspecified and "(repo default)" is selected, the workflow will throw an error.
+- `AI_EDITOR_LANGUAGE_MODEL`: For the given provider, what model to use if the "model" field in the workflow parameters
+  was left empty. If this is unspecified, Manubot AI Editor will select the default model for your chosen provider.
+
+### Multiple Providers
+
+In case you want to use several providers in the same repo, you'll have to register an API key for each provider you
+intend to use.
+Like `PROVIDER_API_KEY`, these keys are also registered as secrets, and can be specified at either the repository or
+organizational level.
+
+We currently support the following secrets, with more to follow as we integrate more providers:
+- `OPENAI_API_KEY`: the API key for the "openai" provider
+- `ANTHROPIC_API_KEY`: the API key for the "anthropic" provider
+
 ### Configuring prompts
 
 In order to revise your manuscript, prompts must be provided to the AI model.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Start with a manuscript repo [forked from Manubot rootstock](https://github.com/
 
 If you prefer to select less options when running the workflow, you can optionally set up default values for the model provider and model at either the repo or organization level.
 
-In your fork's "⚙️ Settings" tab you can optionally create the following Actions repository variables:
-- `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets  the default if "(repo default)" was selected
-  in the workflow parameters. If this is unspecified and "(repo default)" is selected, the workflow will throw an error.
-- `AI_EDITOR_LANGUAGE_MODEL`: specifies what model to use if the "model" field is in the workflow parameters
-  . If this repository variable is unspecified, Manubot AI Editor will select the default model for your chosen provider.
+In your fork's "⚙️ Settings" tab, you can optionally create the folllowing Actions repository variables:
+- `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets this as the default if "(repo default)" was selected in the workflow parameters.
+  If this is unspecified and "(repo default)" is selected, the workflow will throw an error.
+- `AI_EDITOR_LANGUAGE_MODEL`: For the given provider, what model to use if the "model" field in the workflow parameters was left empty.
+  If this is unspecified, Manubot AI Editor will select the default model for your chosen provider.
 
 ### Multiple Providers
 
@@ -56,6 +56,8 @@ Like `PROVIDER_API_KEY`, these keys are also registered as GitHub secrets, and c
 We currently support the following secrets, with more to follow as we integrate more providers:
 - `OPENAI_API_KEY`: the API key for the "openai" provider
 - `ANTHROPIC_API_KEY`: the API key for the "anthropic" provider
+
+See [the API key variables docs](https://github.com/manubot/manubot-ai-editor/blob/main/docs/env-vars.md#provider-api-key-configuration) for more information.
 
 ### Configuring prompts
 
@@ -157,8 +159,7 @@ specific encodings, you can specify the input encoding with the
 `AI_EDITOR_SRC_ENCODING` and the output encoding with the
 `AI_EDITOR_DST_ENCODING` environment variables.
 
-See
-[these variables' help docs](https://github.com/manubot/manubot-ai-editor/blob/main/docs/env-vars.md#encodings)
+See[these variables' help docs](https://github.com/manubot/manubot-ai-editor/blob/main/docs/env-vars.md#encodings)
 for more information.
 
 Also, see [Python 3 Docs: Standard Encodings](https://docs.python.org/3/library/codecs.html#standard-encodings) for

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Start with a manuscript repo [forked from Manubot rootstock](https://github.com/
 If you prefer to select fewer options when running the workflow, you can optionally set up default values for the
 model provider and model at either the repo or organization level.
 
-In your fork's "⚙️ Settings" tab, you can optionally create the folllowing Actions repository variables:
-- `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets this as the default if "(repo default)" was selected
+In your fork's "⚙️ Settings" tab you can optionally create the following Actions repository variables:
+- `AI_EDITOR_MODEL_PROVIDER`: Either "openai" or "anthropic"; sets  the default if "(repo default)" was selected
   in the workflow parameters. If this is unspecified and "(repo default)" is selected, the workflow will throw an error.
-- `AI_EDITOR_LANGUAGE_MODEL`: For the given provider, what model to use if the "model" field in the workflow parameters
-  was left empty. If this is unspecified, Manubot AI Editor will select the default model for your chosen provider.
+- `AI_EDITOR_LANGUAGE_MODEL`: specifies what model to use if the "model" field is in the workflow parameters
+  . If this repository variable is unspecified, Manubot AI Editor will select the default model for your chosen provider.
 
 ### Multiple Providers
 
 In case you want to use several providers in the same repo, you'll have to register an API key for each provider you
 intend to use.
-Like `PROVIDER_API_KEY`, these keys are also registered as secrets, and can be specified at either the repository or
+Like `PROVIDER_API_KEY`, these keys are also registered as GitHub secrets, and can be specified at either the repository or
 organizational level.
 
 We currently support the following secrets, with more to follow as we integrate more providers:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Start with a manuscript repo [forked from Manubot rootstock](https://github.com/
 1. If you haven't already, follow the directions above to create an account and get an API key for your chosen model provider.
 1. In your fork's "⚙️ Settings" tab, make a new Actions repository secret with the name `PROVIDER_API_KEY` and paste in your API key as the secret.
 
-If you prefer to select less options when running the workflow, you can optionally set up default values for the
+If you prefer to select fewer options when running the workflow, you can optionally set up default values for the
 model provider and model at either the repo or organization level.
 
 In your fork's "⚙️ Settings" tab, you can optionally create the folllowing Actions repository variables:

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -16,15 +16,11 @@ support are "openai" for OpenAI and "anthropic" for Anthropic.
 
 ## Provider API Key Configuration
 
-For providers that require API keys, you can specify an API key specific
-to that provider via an environment variable named `<PROVIDER>_API_KEY`.
-For example, for OpenAI, the API key variable would be named `OPENAI_API_KEY`
-and for Anthropic, it would be `ANTHROPIC_API_KEY`.
+For providers that require API keys, you can specify an API key specific to that provider via an environment variable named `<PROVIDER>_API_KEY`.
+For example, for OpenAI, the API key variable would be named `OPENAI_API_KEY` and for Anthropic, it would be `ANTHROPIC_API_KEY`.
 
-Alternatively, you can use the environment variable `PROVIDER_API_KEY` to
-set an API key that will be used for all providers.
-If both a provider-specific key and `PROVIDER_API_KEY` are set, the provider-
-specific key will take precedence.
+Alternatively, you can use the environment variable `PROVIDER_API_KEY` to set an API key that will be used for all providers.
+If both a provider-specific key and `PROVIDER_API_KEY` are set, the provider-specific key will take precedence.
 
 ## Model Configuration
 


### PR DESCRIPTION
The upcoming rootstock PR manubot/rootstock#522 adds a few new optional repo variables and secrets, specifically:

- `AI_EDITOR_MODEL_PROVIDER` which specifies a default model provider when "(repo default)" is selected in the workflow model provider dropdown, and
- `AI_EDITOR_LANGUAGE_MODEL` which specifies a default model to use

The new rootstock PR allows provider-specific API keys in addition to the generic `PROVIDER_API_KEY` already mentioned in the docs.

This PR adds the two variables mentioned above plus these new API key secrets to the README section regarding setting up a rootstock fork and running the ai-editor workflow.
