### PR TITLE
Update pre-commit-lite conditions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,9 +16,10 @@ jobs:
           with:
             python-version: "3.10"
         - uses: pre-commit/action@v3.0.1
+          id: pre_commit
         # run pre-commit ci lite for automated fixes
         - uses: pre-commit-ci/lite-action@v1.1.0
-          if: ${{ !cancelled() }}
+          if: ${{ !cancelled() && steps.pre_commit.outcome == 'failure' }}
   tests:
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # This hook checks yaml files for parseable syntax.
     -   id: check-yaml
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
     -   id: ruff
         args:
@@ -28,7 +28,7 @@ repos:
     -   id: black
         language_version: python3
 -   repo: https://github.com/python-poetry/poetry
-    rev: "2.1.2"
+    rev: "2.1.3"
     hooks:
     -   id: poetry-check
 -   repo: https://github.com/tox-dev/pyproject-fmt


### PR DESCRIPTION
This PR updates the pre-commit-lite conditions so that only failures of pre-commit can trigger updates from pre-commit-lite. Without this change, updates may occur without pre-commit failures.