### PR TITLE
Terminates editing process when invalid API key is used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # This hook checks yaml files for parseable syntax.
     -   id: check-yaml
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.11.11
     hooks:
     -   id: ruff
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # This hook checks yaml files for parseable syntax.
     -   id: check-yaml
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.11.12
     hooks:
     -   id: ruff
         args:

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -1,4 +1,5 @@
 import json
+from logging import getLogger
 import os
 from pathlib import Path
 
@@ -12,6 +13,8 @@ from manubot_ai_editor.utils import (
     get_yaml_field,
     SENTENCE_END_PATTERN,
 )
+
+logger = getLogger(__name__)
 
 
 class ManuscriptEditor:
@@ -136,6 +139,10 @@ class ManuscriptEditor:
             # ensure that we terminate the process if the API key is invalid
             raise e
         except Exception as e:
+            # add some output the log file so the exceptions aren't invisible until you inspect the output
+            logger.debug(f"Error revising paragraph: {e}")
+
+            # if the AI model could not revise the paragraph, we write an error
             error_message = f"""
 <!--
 ERROR: the paragraph below could not be revised with the AI model due to the following error:

--- a/libs/manubot_ai_editor/editor.py
+++ b/libs/manubot_ai_editor/editor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import charset_normalizer
 
 from manubot_ai_editor import env_vars
+from manubot_ai_editor.exceptions import APIKeyInvalidError
 from manubot_ai_editor.prompt_config import ManuscriptPromptConfig, IGNORE_FILE
 from manubot_ai_editor.models import ManuscriptRevisionModel
 from manubot_ai_editor.utils import (
@@ -131,6 +132,9 @@ class ManuscriptEditor:
 
             if paragraph_revised.strip() == "":
                 raise Exception("The AI model returned an empty string ('')")
+        except APIKeyInvalidError as e:
+            # ensure that we terminate the process if the API key is invalid
+            raise e
         except Exception as e:
             error_message = f"""
 <!--

--- a/libs/manubot_ai_editor/exceptions.py
+++ b/libs/manubot_ai_editor/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Exception classes that are shared across modules in the project.
+"""
+
+
+class APIKeyInvalidError(Exception):
+    """
+    Raised when a provider request is attempted with an invalid API key.
+    """
+
+    pass

--- a/libs/manubot_ai_editor/models.py
+++ b/libs/manubot_ai_editor/models.py
@@ -364,7 +364,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
         # construct the provider's client after all the rest of
         # the settings above have been processed
         client_cls = provider.clients()[self.endpoint]
-        self.model_provider = model_provider
+        self._model_provider = model_provider
         self.client = client_cls(
             api_key=api_key,
             **self.model_parameters,
@@ -690,7 +690,7 @@ class GPT3CompletionModel(ManuscriptRevisionModel):
                     # reported as a warning in the emitted content as all other
                     # exceptions are.
                     raise APIKeyInvalidError(
-                        f"Invalid API key used for provider '{self.model_provider}'"
+                        f"Invalid API key used for provider '{self._model_provider}'"
                     ) from e
                 elif "overloaded" in error_message:
                     time.sleep(5)

--- a/tests/test_model_basics.py
+++ b/tests/test_model_basics.py
@@ -384,8 +384,11 @@ def test_model_provider_get_models_live(caplog, request, provider_name: str):
         ), "mocked_model_list marker should not be present for a live API test"
 
         # check that we didn't resort to not checking the model, since
-        # GPT3CompletionModel just regsisters a warning if the model list can't
+        # GPT3CompletionModel just registers a warning if the model list can't
         # be retrieved
+
+        # this assertion failing indicates that something went wrong with
+        # querying the provider API for the model list (typically an invalid API key)
         assert "Unable to obtain model list from provider " not in caplog.text
 
 


### PR DESCRIPTION
Previously, if any exception occurred during the paragraph revision process, the tool would write it as a comment in the output: https://github.com/manubot/manubot-ai-editor/blob/main/libs/manubot_ai_editor/editor.py#L127-L141. This causes the ai-revision workflow to appear to succeed even when the API key required to invoke the provider is invalid.

This PR adds a new exception, `exceptions.APIKeyInvalidError`, that is thrown in `GPT3CompletionModel.revise_paragraph()` and caught+re-raised in the editor prior to the catch-all that writes the exception to the output. This allows the tool to terminate as soon as an invalid API key is used, and for the workflow to correctly register the run as having failed.

The PR also adds the `exceptions` module, which we can use going forward for exceptions that pertain to more than a single module.